### PR TITLE
add advanced params section with pathing delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ redemption | Hotkey for redemption
 holy_shield | Hotkey for Holy Shield
 blessed_hammer | Hotkey for Blessed Hammer
 
+ [advanced_options]             | Descriptions                                
+--------------------------------|---------------------------------------------
+pathing_delay_factor | A linear scaling factor, between 1 and 10, applied to pathing delays.
+
  [items]                        | Descriptions                                
 --------------------------------|---------------------------------------------
 item_type | 0: Item will not be picked up. 1: Item will be picked up. 2: Item will be picked up and a discord message will be sent.

--- a/params.ini
+++ b/params.ini
@@ -68,6 +68,10 @@ redemption=3
 holy_shield=4
 blessed_hammer=5
 
+[advanced_options]
+;===== don't touch unless you know what you're doing =====
+pathing_delay_factor=5
+
 [items]
 ;=====MISC=====
 misc_flawless_amethyst=1

--- a/src/char/i_char.py
+++ b/src/char/i_char.py
@@ -51,6 +51,7 @@ class IChar:
             mouse.click(button="right")
             wait(self._cast_duration, self._cast_duration + 0.04)
         else:
+            factor = self._config.advanced_options["pathing_delay_factor"]
             # in case we want to walk we actually want to move a bit before the point cause d2r will always "overwalk"
             pos_screen = self._screen.convert_monitor_to_screen(pos_monitor)
             pos_abs = self._screen.convert_screen_to_abs(pos_screen)
@@ -58,8 +59,8 @@ class IChar:
             adjust_factor = (dist - 50) / dist
             pos_abs = [int(pos_abs[0] * adjust_factor), int(pos_abs[1] * adjust_factor)]
             x, y = self._screen.convert_abs_to_monitor(pos_abs)
-            mouse.move(x, y, randomize=5, delay_factor=[0.7, 1.0])
-            wait(0.03, 0.05)
+            mouse.move(x, y, randomize=5, delay_factor=[factor*0.14, factor*0.2])
+            wait(factor*0.006, factor*0.01)
             mouse.click(button="left")
             wait(0.02, 0.03)
             if self._config.char["slow_walk"]:

--- a/src/config.py
+++ b/src/config.py
@@ -86,6 +86,10 @@ class Config:
         self.hammerdin = self._config["hammerdin"]
         if "hammerdin" in self._custom:
             self.hammerdin.update(self._custom["hammerdin"])
+        
+        self.advanced_options = {
+            "pathing_delay_factor": min(max(int(self._select_val("advanced_options", "pathing_delay_factor")),1),10)
+        }
 
         self.items = {}
         for key in self._config["items"]:


### PR DESCRIPTION
Adds a new params section, "advanced_options"
Adds a new param to the advanced_options section, "pathing_delay_factor"

The pathing delay factor will allow users to scale the otherwise static delays in the pathing `move` operations based on their own needs.