### PR TITLE
Named bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ run_shenk=0
 
  [general]                      | Descriptions
 --------------------------------|---------------------------------------------
+name | Name used in terminal and discord messages
 monitor | Select on which monitor D2R is running in case multiple are available
 res | Resolution settings can be any of [1920_1080, 1280_720]
 offset_top | Your D2R windows offset from top of the screen (including the window bar). For fullscreen leave at 0.

--- a/params.ini
+++ b/params.ini
@@ -1,4 +1,5 @@
 [general]
+name=Botty
 monitor=0
 res=1920_1080
 offset_top=0

--- a/src/bot.py
+++ b/src/bot.py
@@ -95,7 +95,7 @@ class Bot:
 
     def trigger_or_stop(self, name: str):
         if self._pausing:
-            Logger.info("Botty is now pausing")
+            Logger.info(f"{self._config.general['name']} is now pausing")
         while self._pausing:
             time.sleep(0.2)
         if not self._stopping:

--- a/src/config.py
+++ b/src/config.py
@@ -25,7 +25,7 @@ class Config:
             self._custom.read('custom.ini')
 
         self.general = {
-            "name": self._select_val("general", "name")
+            "name": self._select_val("general", "name"),
             "monitor": int(self._select_val("general", "monitor")),
             "res": self._select_val("general", "res"),
             "offset_top": int(self._select_val("general", "offset_top")),

--- a/src/config.py
+++ b/src/config.py
@@ -25,6 +25,7 @@ class Config:
             self._custom.read('custom.ini')
 
         self.general = {
+            "name": self._select_val("general", "name")
             "monitor": int(self._select_val("general", "monitor")),
             "res": self._select_val("general", "res"),
             "offset_top": int(self._select_val("general", "offset_top")),

--- a/src/pickit.py
+++ b/src/pickit.py
@@ -74,7 +74,7 @@ class PickIt:
                             if self._config.general["custom_discord_hook"] != "":
                                 send_discord_thread = threading.Thread(
                                     target=send_discord,
-                                    args=(f"Botty just found: {closest_item.name}", self._config.general["custom_discord_hook"])
+                                    args=(f"{self._config.general['name']} just found: {closest_item.name}", self._config.general["custom_discord_hook"])
                                 )
                                 send_discord_thread.daemon = True
                                 send_discord_thread.start()

--- a/src/run.py
+++ b/src/run.py
@@ -24,7 +24,7 @@ def run_bot(config: Config):
     keyboard.add_hotkey(config.general['resume_key'], lambda: bot.toggle_pause())
     while 1:
         if bot.current_game_length() > config.general["max_game_length_s"]:
-            Logger.info("Max game length reached. Attempting to restart botty!")
+            Logger.info(f"Max game length reached. Attempting to restart {config.general['name']}!")
             bot.stop()
             kill_thread(bot_thread)
             if game_recovery.go_to_hero_selection():
@@ -35,9 +35,9 @@ def run_bot(config: Config):
     if do_restart:
         run_bot(config)
     else:
-        Logger.error("Botty could not recover from a max game length violation. Shutting down everything.")
+        Logger.error(f"{config.general['name']} could not recover from a max game length violation. Shutting down everything.")
         if config.general["custom_discord_hook"]:
-            send_discord("Botty got stuck and can not resume", config.general["custom_discord_hook"])
+            send_discord(f"{config.general['name']} got stuck and can not resume", config.general["custom_discord_hook"])
         close_down_d2()
 
 
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     # If anything seems to go wrong, press f12 and the bot will force exit
     keyboard.add_hotkey(config.general["exit_key"], lambda: Logger.info(f'Force Exit') or os._exit(1))
 
-    print(f"============ Botty {__version__} ============")
+    print(f"============ Botty {__version__} [name: {config.general['name']}] ============")
     print("\nFor gettings started and documentation\nplease read https://github.com/aeon0/botty\n")
     table = BeautifulTable()
     table.rows.append([config.general['auto_settings_key'], "Adjust D2R settings"])


### PR DESCRIPTION
Add the possibility to name the bot in terminal and discord.

When using several bots, it is convenient to know which one is stuck, or has dropped an item, when looking at the discord channel.
This (trivial) PR implement a very basic way to do it: the user can register in custom.ini a `name` field which is then used in `send_discord_thread`

**Example**
Setting in custom.ini
`name=My favorite bot`
will lead to message such as
> My favorite bot just found: uniq_armor_ormus_robes (v0.2.2-dev)