### PR TITLE
Moves the mouse to the corner before taking a screenshot. 

### DIFF
--- a/src/pickit.py
+++ b/src/pickit.py
@@ -33,7 +33,7 @@ class PickIt:
         time.sleep(1.0) # sleep needed here to give d2r time to display items on screen on keypress
         #Creating a screenshot of the current loot
         if self._config.general["loot_screenshots"]:
-            img = self._screen.grab()
+            img = self._screen.grab(hide_mouse=True)
             cv2.imwrite("./loot_screenshots/info_debug_drop_" + time.strftime("%Y%m%d_%H%M%S") + ".png", img)
             Logger.debug("Took a screenshot of current loot")
         start = time.time()
@@ -44,7 +44,7 @@ class PickIt:
                 time_out = True
                 Logger.warning("Got stuck during pickit, skipping it this time...")
                 break
-            img = self._screen.grab()
+            img = self._screen.grab(hide_mouse=True)
             item_list = self._item_finder.search(img)
 
             # Check if we need to pick up certain pots more pots
@@ -68,7 +68,7 @@ class PickIt:
                     # if potion is picked up, record it in the belt manager
                     if "potion" in closest_item.name:
                         self._belt_manager.picked_up_pot(closest_item.name)
-                    # no need to stash potions, scrolls, or gold 
+                    # no need to stash potions, scrolls, or gold
                     if "potion" not in closest_item.name and "tp_scroll" != closest_item.name and "misc_gold" not in closest_item.name:
                         found_items = True
                     Logger.info(f"Picking up: {closest_item.name}")

--- a/src/screen.py
+++ b/src/screen.py
@@ -5,6 +5,7 @@ import time
 from logger import Logger
 from typing import Tuple
 from config import Config
+from utils.custom_mouse import mouse
 import os
 
 
@@ -50,7 +51,10 @@ class Screen:
         monitor_coord = self.convert_screen_to_monitor(screen_coord)
         return monitor_coord
 
-    def grab(self) -> np.ndarray:
+    def grab(self, hide_mouse=False) -> np.ndarray:
+        if hide_mouse:
+            mouse.move(0, 0)  # Moving the mouse to the edge of the screen to not cover any loot.
+            time.sleep(0.1)
         img = np.array(self._sct.grab(self._monitor_roi))
         return img[:, :, :3]
 


### PR DESCRIPTION
Prevents thus mouse from covering loot.

Here an example where this might have happened (ring got not picked up).
![not picked up ring - info_debug_drop_20211122_203831](https://user-images.githubusercontent.com/8392548/143197636-e8f0ef22-690a-400b-bf18-f01bc90c6992.png)

