### PR TITLE
Fix getting stuck at discarding

### DIFF
--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -321,7 +321,15 @@ class UiManager():
                 else:
                     # make sure there is actually an item
                     time.sleep(0.3)
+                    curr_pos = mouse.get_position()
+                    # move mouse away from inventory, for some reason it was sometimes included in the grabed img
+                    top_left_slot = (self._config.ui_pos["inventory_top_left_slot_x"], self._config.ui_pos["inventory_top_left_slot_y"])
+                    move_to = (top_left_slot[0] - 300, top_left_slot[1] - 200)
+                    x, y = self._screen.convert_screen_to_monitor(move_to)
+                    mouse.move(x, y, randomize=40, delay_factor=[1.0, 1.5])
                     hovered_item = self._screen.grab()
+                    mouse.move(*curr_pos, randomize=2)
+                    wait(0.4, 0.6)
                     slot_pos, slot_img = self.get_slot_pos_and_img(self._config, hovered_item, column, row)
                     if self._slot_has_item(slot_img):
                         if self._config.general["info_screenshots"]:
@@ -438,4 +446,4 @@ if __name__ == "__main__":
     template_finder = TemplateFinder(screen)
     item_finder = ItemFinder()
     ui_manager = UiManager(screen, template_finder)
-    ui_manager.start_game()
+    ui_manager.stash_all_items(5, item_finder)

--- a/src/utils/custom_mouse.py
+++ b/src/utils/custom_mouse.py
@@ -270,6 +270,10 @@ class mouse:
     @staticmethod
     def release(button):
         _mouse.release(button)
+    
+    @staticmethod
+    def get_position():
+        return _mouse.get_position()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When checking if we want to discard an item we check if there really is an item at that current location. If the screenshot includes the cursor this check returns true. By discarding an item that is not there we cancel the stash screen and everything goes down the toilet from there...

We get stuck, we think the stash tab is full...