### PR TITLE
fix(sorc): hold mouse during attack delay

### DIFF
--- a/src/char/sorceress.py
+++ b/src/char/sorceress.py
@@ -65,8 +65,9 @@ class Sorceress(IChar):
             y = cast_pos_abs[1] + (random.random() * 2*spray - spray)
             cast_pos_monitor = self._screen.convert_abs_to_monitor((x, y))
             mouse.move(*cast_pos_monitor)
-            mouse.click(button="left")
+            mouse.press(button="left")
             wait(delay[0], delay[1])
+            mouse.release(button="left")
         keyboard.send(self._char_config["stand_still"], do_press=False)
 
     def _main_attack(self, cast_pos_abs: Tuple[float, float], delay: float, spray: float = 10):
@@ -75,8 +76,9 @@ class Sorceress(IChar):
         y = cast_pos_abs[1] + (random.random() * 2*spray - spray)
         cast_pos_monitor = self._screen.convert_abs_to_monitor((x, y))
         mouse.move(*cast_pos_monitor)
-        mouse.click(button="right")
+        mouse.press(button="right")
         wait(delay[0], delay[1])
+        mouse.release(button="right")
 
     def kill_pindle(self) -> bool:
         delay = [0.2, 0.3]

--- a/src/death_manager.py
+++ b/src/death_manager.py
@@ -51,6 +51,10 @@ class DeathManager:
                 keyboard.release(self._config.char["stand_still"])
                 wait(0.1, 0.2)
                 keyboard.release(self._config.char["show_items"])
+                wait(0.1, 0.2)
+                mouse.release(button="right")
+                wait(0.1, 0.2)
+                mouse.release(button="left")
             time.sleep(6)
             if self._template_finder.search("D2_LOGO_HS", self._screen.grab(), roi=self._config.ui_roi["hero_selection_logo"]).valid:
                 # in this case chicken executed and left the game, but we were still dead.

--- a/src/health_manager.py
+++ b/src/health_manager.py
@@ -4,6 +4,7 @@ from belt_manager import BeltManager
 import cv2
 import time
 import keyboard
+from utils.custom_mouse import mouse
 from utils.misc import kill_thread, cut_roi, color_filter, wait
 from logger import Logger
 from screen import Screen
@@ -69,6 +70,10 @@ class HealthManager:
         keyboard.release(self._config.char["stand_still"])
         wait(0.02, 0.05)
         keyboard.release(self._config.char["show_items"])
+        wait(0.02, 0.05)
+        mouse.release(button="left")
+        wait(0.02, 0.05)
+        mouse.release(button="right")
         time.sleep(0.01)
         self._ui_manager.save_and_exit(does_chicken=True)
         self._did_chicken = True


### PR DESCRIPTION
Small change to keep the mouse held down during this attack delay, seems to speed up the attack sequence by a few frames and I haven't had any issues in my testing.