### PR TITLE
Fix rapid-fire rejuvs edge case

### DIFF
--- a/src/health_manager.py
+++ b/src/health_manager.py
@@ -93,9 +93,11 @@ class HealthManager:
                 mana_percentage = self.get_mana(img)
                 # check rejuv
                 success_drink_rejuv = False
-                if health_percentage < self._config.char["take_rejuv_potion_health"] or \
-                   mana_percentage < self._config.char["take_rejuv_potion_mana"]:
+                last_drink = time.time() - self._last_rejuv
+                if (health_percentage < self._config.char["take_rejuv_potion_health"] and last_drink > 1) or \
+                   (mana_percentage < self._config.char["take_rejuv_potion_mana"] and last_drink > 2):
                     success_drink_rejuv = self._belt_manager.drink_potion("rejuv", stats=[health_percentage, mana_percentage])
+                    self._last_rejuv = time.time()
                 # in case no rejuv was used, check for chicken, health pot and mana pot usage
                 if not success_drink_rejuv:
                     # check health


### PR DESCRIPTION
Ran into a mana burn champ and had all 8 full rejuvs drained within 2 seconds. 

```
[2021-11-30 22:02:25,394] DEBUG      Waiting for Template ['ELDRITCH_0', 'ELDRITCH_START']
[2021-11-30 22:02:38,542] DEBUG      Drink rejuv potion in slot 2. HP: 97.9%, Mana: 0.0%
[2021-11-30 22:02:38,676] DEBUG      Drink rejuv potion in slot 2. HP: 97.9%, Mana: 0.0%
[2021-11-30 22:02:38,816] DEBUG      Drink rejuv potion in slot 2. HP: 97.9%, Mana: 0.0%
[2021-11-30 22:02:39,106] DEBUG      Took a screenshot of current loot
[2021-11-30 22:02:39,457] DEBUG      Drink rejuv potion in slot 2. HP: 96.7%, Mana: 0.0%
[2021-11-30 22:02:39,600] DEBUG      Drink rejuv potion in slot 4. HP: 96.7%, Mana: 0.0%
[2021-11-30 22:02:39,735] DEBUG      Drink rejuv potion in slot 4. HP: 96.7%, Mana: 0.0%
[2021-11-30 22:02:40,244] DEBUG      Drink rejuv potion in slot 4. HP: 98.9%, Mana: 0.0%
[2021-11-30 22:02:40,386] DEBUG      Drink rejuv potion in slot 4. HP: 98.9%, Mana: 0.0%
[2021-11-30 22:02:40,388] DEBUG      Stop health monitoring
```

https://user-images.githubusercontent.com/9866239/144169056-f22c5003-feb0-46d9-bb63-6dbeff704825.mp4

This PR utilizes the initialized _last_rejuv variable for HP and mana to avoid edge cases like this, allowing a small delay in HP and MP rejuvs. Feel free to adjust the delay as you think is appropriate.

