### PR TITLE
Add support for forcing the bot to re-apply buffs prior to running sh…

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ belt_rejuv_columns | Number of belt columns for rejuv potions
 belt_hp_columns | Number of belt columns for healing potions
 belt_mp_columns | Number of belt columns for mana potions
 cta_available | 0: no cta available, 1: cta is available and should be used during prebuff
+force_shenk_cta | o: no, 1: yes. If you want to force bot to refresh buff's before starting shenk/eld run.
 weapon_switch | Hotkey for "weapon switch" (only needed if cta_available=1)
 battle_order | Hotkey for battle order from cta (only needed if cta_available=1)
 battle_command | Hotkey for battle command from cta (only needed if cta_available=1)

--- a/params.ini
+++ b/params.ini
@@ -1,7 +1,7 @@
 ; There is detailed documentation for each parameter in the README.md
 [general]
 name=Botty
-monitor=0
+monitor=1
 max_game_length_s=320
 resume_key=f11
 exit_key=f12
@@ -52,6 +52,7 @@ belt_rejuv_columns=2
 belt_hp_columns=1
 belt_mp_columns=1
 cta_available=0
+force_shenk_cta=0
 weapon_switch=x
 battle_orders=f7
 battle_command=f8

--- a/src/bot.py
+++ b/src/bot.py
@@ -309,7 +309,7 @@ class Bot:
                 self.success = bot._template_finder.search_and_wait(["ELDRITCH_0", "ELDRITCH_START"], threshold=0.65, time_out=20).valid
                 if not self.success:
                     return
-                if not bot._pre_buffed:
+                if not bot._pre_buffed or bot._config.char["force_shenk_cta"]:
                     bot._char.pre_buff()
                     bot._pre_buffed = 1
                 wait(0.2, 0.3)

--- a/src/config.py
+++ b/src/config.py
@@ -70,6 +70,7 @@ class Config:
             "belt_mp_columns": int(self._select_val("char", "belt_mp_columns")),
             "stash_gold": bool(int(self._select_val("char", "stash_gold"))),
             "cta_available": bool(int(self._select_val("char", "cta_available"))),
+            "force_shenk_cta": bool(int(self._select_val("char", "force_shenk_cta"))),
             "weapon_switch": self._select_val("char", "weapon_switch"),
             "battle_orders": self._select_val("char", "battle_orders"),
             "battle_command": self._select_val("char", "battle_command"),


### PR DESCRIPTION
Players can now choose to force the bot to re-apply their buffs after taking the frigid WP to ensure their buffs are still up when they run eld / shenk. 