### PR TITLE
Fix creash on death and chicken delay

### DIFF
--- a/src/death_manager.py
+++ b/src/death_manager.py
@@ -44,7 +44,6 @@ class DeathManager:
     def handle_death_screen(self):
         template_match = self._template_finder.search("YOU_HAVE_DIED", self._screen.grab(), threshold=0.9, roi=self._config.ui_roi["death"])
         if template_match.valid:
-            self._died = True
             Logger.warning("You have died!")
             # first wait a bit to make sure health manager is done with its chicken stuff which obviously failed
             if self._callback is not None:
@@ -63,6 +62,7 @@ class DeathManager:
                 # in this case chicken executed and left the game, but we were still dead.
                 return True
             keyboard.send("esc")
+            self._died = True
             return True
         return False
 
@@ -71,6 +71,7 @@ class DeathManager:
         self._died = False
         Logger.info("Start Death monitoring")
         while self._do_monitor:
+            if self._died: continue
             time.sleep(self._loop_delay) # no need to do this too frequent, when we died we are not in a hurry...
             # Wait until the flag is reset by run.py
             if self._died: continue

--- a/src/game_stats.py
+++ b/src/game_stats.py
@@ -53,7 +53,9 @@ class GameStats:
         Logger.info(f"Starting game #{self._game_counter}")
 
     def log_end_game(self):
-        elapsed_time = time.time() - self._timer
+        elapsed_time = 0
+        if self._timer is not None:
+            elapsed_time = time.time() - self._timer
         self._timer = None
         Logger.info(f"End game. Elapsed time: {elapsed_time:.2f}s")
 
@@ -73,7 +75,7 @@ class GameStats:
         self._timer = self._timer + pausetime
         self._paused = False
 
-    def get_current_game_length(self):        
+    def get_current_game_length(self):
         if self._timer is None:
             return 0
         if self._paused:

--- a/src/health_manager.py
+++ b/src/health_manager.py
@@ -94,7 +94,6 @@ class HealthManager:
         wait(0.02, 0.05)
         mouse.release(button="right")
         time.sleep(0.01)
-        wait(1.0, 2.0)
         self._ui_manager.save_and_exit(does_chicken=True)
         self._did_chicken = True
         self._pausing = True


### PR DESCRIPTION
Forgot to remove a delay in chicken that was used to test the situation when chicken wants to execute but meanwhile your char dies.

Also fixes a bug that self._timer is None when you die on end_game()