### PR TITLE
Fix for crash on A2 Summoner for Sorceress

### DIFF
--- a/src/char/sorceress/blizz_sorc.py
+++ b/src/char/sorceress/blizz_sorc.py
@@ -222,13 +222,12 @@ class BlizzSorc(Sorceress):
 
     def kill_summoner(self) -> bool:
         # Attack
-        delay = [0.2, 0.3]
         cast_pos_abs = np.array([0, 0])
         pos_m = self._screen.convert_abs_to_monitor((-20, 20))
         mouse.move(*pos_m, randomize=80, delay_factor=[0.5, 0.7])
         for _ in range(int(self._char_config["atk_len_arc"])):
-            self._right_attack(cast_pos_abs, delay, 11)
-            self._left_attack(cast_pos_abs, delay, 11)
+            self._blizzard(cast_pos_abs, spray=11)
+            self._ice_blast(cast_pos_abs, spray=11)
         wait(self._cast_duration, self._cast_duration + 0.2)
         return True
     

--- a/src/char/sorceress/light_sorc.py
+++ b/src/char/sorceress/light_sorc.py
@@ -147,13 +147,12 @@ class LightSorc(Sorceress):
 
     def kill_summoner(self) -> bool:
         # Attack
-        delay = [0.2, 0.3]
         cast_pos_abs = np.array([0, 0])
         pos_m = self._screen.convert_abs_to_monitor((-20, 20))
         mouse.move(*pos_m, randomize=80, delay_factor=[0.5, 0.7])
         for _ in range(int(self._char_config["atk_len_arc"])):
-            self._right_attack(cast_pos_abs, delay, 11)
-            self._left_attack(cast_pos_abs, delay, 11)
+            self._chain_lightning(cast_pos_abs, spray=11)
+        self._lightning(cast_pos_abs, spray=50)
         wait(self._cast_duration, self._cast_duration + 0.2)
         return True
 

--- a/src/char/sorceress/light_sorc.py
+++ b/src/char/sorceress/light_sorc.py
@@ -152,7 +152,7 @@ class LightSorc(Sorceress):
         mouse.move(*pos_m, randomize=80, delay_factor=[0.5, 0.7])
         for _ in range(int(self._char_config["atk_len_arc"])):
             self._chain_lightning(cast_pos_abs, spray=11)
-        self._lightning(cast_pos_abs, spray=50)
+            self._lightning(cast_pos_abs, spray=50)
         wait(self._cast_duration, self._cast_duration + 0.2)
         return True
 


### PR DESCRIPTION
I was getting a crash when trying A2 summoner with my blizz sorc, looks like the right_attack and left_attack methods are only defined on Trapsin class and not for the Sorceress base class used by light and blizz ones.

I replaced the calls by the same strategy used for pindleskin and it works, probably not the best one but working and not crashing.