### PR TITLE
Pre-Buff before each arm - if do_pre_buff is enabled.

### DIFF
--- a/src/run/arcane.py
+++ b/src/run/arcane.py
@@ -80,10 +80,11 @@ class Arcane:
 
         picked_up_items = False
         self.used_tps = 0
-        if do_pre_buff:
-            self._char.pre_buff()
 
         for i, data in enumerate(path_arr):
+            if do_pre_buff:
+                self._char.pre_buff()
+
             # calibrating at start and moving towards the end of the arm
             self._pather.traverse_nodes([data.calib_node_start], self._char, force_tp=True)
             if not self._pather.traverse_nodes_fixed(data.static_path_forward, self._char):


### PR DESCRIPTION
Instead of just applying pre-buff once at the start of the whole Arcane Sanctuary, it now applies it before checking each "arm" of the map.