### PR TITLE
fix duplicate bot name in status update message

### DIFF
--- a/src/api/discord_embeds.py
+++ b/src/api/discord_embeds.py
@@ -64,6 +64,7 @@ class DiscordEmbeds(GenericApi):
         self._send_embed(e)
 
     def send_message(self, msg: str):
+        msg = f"{self._config.general['name']}: {msg}"
         e = discord.Embed(title=f"Update:", description=f"```{msg}```", color=Color.dark_teal())
         if not self._config.general['discord_status_condensed']:
             e.set_thumbnail(url=f"{self._psnURL}36L4a4994.png")

--- a/src/game_stats.py
+++ b/src/game_stats.py
@@ -155,7 +155,10 @@ class GameStats:
         return msg
 
     def _send_status_update(self):
-        msg = f"{self._config.general['name']}: Status Report\n{self._create_msg()}\nVersion: {__version__}"
+        if self._config.general["message_api_type"] == "generic_api":
+            msg = f"Status Report\n{self._create_msg()}\nVersion: {__version__}"
+        else:
+            msg = f"{self._config.general['name']}: Status Report\n{self._create_msg()}\nVersion: {__version__}"
         self._messenger.send_message(msg)
 
     def _save_stats_to_file(self):

--- a/src/game_stats.py
+++ b/src/game_stats.py
@@ -155,10 +155,7 @@ class GameStats:
         return msg
 
     def _send_status_update(self):
-        if self._config.general["message_api_type"] == "generic_api":
-            msg = f"Status Report\n{self._create_msg()}\nVersion: {__version__}"
-        else:
-            msg = f"{self._config.general['name']}: Status Report\n{self._create_msg()}\nVersion: {__version__}"
+        msg = f"Status Report\n{self._create_msg()}\nVersion: {__version__}"
         self._messenger.send_message(msg)
 
     def _save_stats_to_file(self):


### PR DESCRIPTION
When the generic_api is in use, the bot name appears twice at the start of each status update message, because the bot name is added at the start by both the GameStats `_send_status_update` method and the GenericApi `_send` method.

example of bug:
![example](https://i.imgur.com/8el47zP.png)

This commit changes the behavior of the _send_status_update method. If the generic_api is in use, it will avoid adding the bot name to the start of the message.

