### PR TITLE
Add option to fill shared stash tabs first (useful for HC characters)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ run_shenk=0
 | always_repair      | 0: Will only repair when needed, 1: Will repair at the start of each run (EXPENSIVE FOR HIGH RUNEWORDS) |
 | id_items           | Will identify items at cain before stashing them. Cain must be rescued for this to work.|
 | open_chests        | Open up chests in some places. E.g. on dead ends of arcane. Note: currently bad runtime. |
+| fill_shared_stash_first | Fill stash tabs starting from right to left, filling personal stash last |
 
 ### Builds
 | [sorceress]   | Descriptions                                                                  |

--- a/config/params.ini
+++ b/config/params.ini
@@ -96,6 +96,7 @@ pre_buff_every_run=1
 always_repair=0
 id_items=0
 open_chests=1
+fill_shared_stash_first=0
 
 ; ===========================
 ; ==== Builds: Sorceress ====

--- a/src/char/hammerdin.py
+++ b/src/char/hammerdin.py
@@ -114,7 +114,7 @@ class Hammerdin(IChar):
         # Check out the node screenshot in assets/templates/trav/nodes to see where each node is at
         atk_len = self._char_config["atk_len_trav"]
         # Go inside and hammer a bit
-        self._pather.traverse_nodes([228, 229], self, time_out=2.5, force_tp=True, do_pre_move=False)
+        self._pather.traverse_nodes([228, 229], self, time_out=2.5, force_tp=True)
         self._cast_hammers(atk_len)
         # Move a bit back and another round
         self._move_and_attack((40, 20), atk_len)

--- a/src/char/hammerdin.py
+++ b/src/char/hammerdin.py
@@ -114,7 +114,7 @@ class Hammerdin(IChar):
         # Check out the node screenshot in assets/templates/trav/nodes to see where each node is at
         atk_len = self._char_config["atk_len_trav"]
         # Go inside and hammer a bit
-        self._pather.traverse_nodes([228, 229], self, time_out=2.5, force_tp=True)
+        self._pather.traverse_nodes([228, 229], self, time_out=2.5, force_tp=True, do_pre_move=False)
         self._cast_hammers(atk_len)
         # Move a bit back and another round
         self._move_and_attack((40, 20), atk_len)

--- a/src/config.py
+++ b/src/config.py
@@ -159,6 +159,7 @@ class Config:
             "use_merc": bool(int(Config._select_val("char", "use_merc"))),
             "id_items": bool(int(Config._select_val("char", "id_items"))),
             "open_chests": bool(int(Config._select_val("char", "open_chests"))),
+            "fill_shared_stash_first": bool(int(Config._select_val("char", "fill_shared_stash_first"))),
             "pre_buff_every_run": bool(int(Config._select_val("char", "pre_buff_every_run"))),
             "cta_available": bool(int(Config._select_val("char", "cta_available"))),
             "weapon_switch": Config._select_val("char", "weapon_switch"),

--- a/src/ui/ui_manager.py
+++ b/src/ui/ui_manager.py
@@ -28,7 +28,10 @@ class UiManager():
         self._messenger = Messenger()
         self._game_stats = game_stats
         self._screen = screen
-        self._curr_stash = {"items": 0, "gold": 0} #0: personal, 1: shared1, 2: shared2, 3: shared3
+        self._curr_stash = {
+            "items": 3 if self._config.char["fill_shared_stash_first"] else 0,
+            "gold": 0
+        } #0: personal, 1: shared1, 2: shared2, 3: shared3
 
     def use_wp(self, act: int, idx: int):
         """
@@ -459,8 +462,10 @@ class UiManager():
             Logger.info("Stash page is full, selecting next stash")
             if self._config.general["info_screenshots"]:
                 cv2.imwrite("./info_screenshots/debug_info_inventory_not_empty_" + time.strftime("%Y%m%d_%H%M%S") + ".png", img)
-            self._curr_stash["items"] += 1
-            if self._curr_stash["items"] > 3:
+            
+            # if filling shared stash first, we decrement from 3, otherwise increment
+            self._curr_stash["items"] += -1 if self._config.char["fill_shared_stash_first"] else 1
+            if (self._config.char["fill_shared_stash_first"] and self._curr_stash["items"] < 0) or self._curr_stash["items"] > 3:
                 Logger.error("All stash is full, quitting")
                 if self._config.general["custom_message_hook"]:
                     self._messenger.send_stash()


### PR DESCRIPTION
Added an option fill_shared_stash_first to params.ini

When true, it will stash loot starting from the rightmost stash tab going left (personal tab last). That way dead HC characters can still at least recover the loot they found during their last session.