### PR TITLE
Added a fix for walking characters getting stuck looting in Trav

### DIFF
--- a/src/run/trav.py
+++ b/src/run/trav.py
@@ -59,7 +59,8 @@ class Trav:
             picked_up_items |= self._pickit.pick_up_items(self._char, is_at_trav=True)
         else:
             # Walk back through the door and inside to pick up anything we couldn't from downstairs
-            self._pather.traverse_nodes([228, 229], self._char, time_out=3)
+            if not self._pather.traverse_nodes([226, 228], self._char, time_out=3, force_move=True):
+                not self._pather.traverse_nodes([230, 229, 228], self._char, time_out=3, force_move=True)
             picked_up_items |= self._pickit.pick_up_items(self._char, is_at_trav=True)
             wait(0.2, 0.3)
         # Make sure we go back to the center to not hide the tp

--- a/src/run/trav.py
+++ b/src/run/trav.py
@@ -57,6 +57,11 @@ class Trav:
             if not self._pather.traverse_nodes([229], self._char, time_out=2.5):
                 self._pather.traverse_nodes([228, 229], self._char, time_out=2.5)
             picked_up_items |= self._pickit.pick_up_items(self._char, is_at_trav=True)
+        else:
+            # Walk back through the door and inside to pick up anything we couldn't from downstairs
+            self._pather.traverse_nodes([228, 229], self._char, time_out=3)
+            picked_up_items |= self._pickit.pick_up_items(self._char, is_at_trav=True)
+            wait(0.2, 0.3)
         # Make sure we go back to the center to not hide the tp
         self._pather.traverse_nodes([230], self._char, time_out=2.5)
         return (Location.A3_TRAV_CENTER_STAIRS, picked_up_items)


### PR DESCRIPTION
Frequently, when a walking character ends up downstairs below the window in Trav while looting, and there are things inside the building, it will get stuck. To fix that, I added a step for characters that can't teleport that will walk them back through the door and inside the room to try looting again.