### PR TITLE
Improved walking Hammerdin in Trav (clears it more consistently w/o getting stuck and loots everything)

### DIFF
--- a/src/char/hammerdin.py
+++ b/src/char/hammerdin.py
@@ -113,22 +113,32 @@ class Hammerdin(IChar):
             wait(0.05, 0.15)
         # Check out the node screenshot in assets/templates/trav/nodes to see where each node is at
         atk_len = self._char_config["atk_len_trav"]
-        # Go inside and hammer a bit
-        self._pather.traverse_nodes([228, 229], self, time_out=2.5, force_tp=True)
-        self._cast_hammers(atk_len)
-        # Move a bit back and another round
-        self._move_and_attack((40, 20), atk_len)
         # Here we have two different attack sequences depending if tele is available or not
         if self.can_teleport():
+            # Go inside and hammer a bit
+            self._pather.traverse_nodes([228, 229], self, time_out=2.5, force_tp=True)
+            self._cast_hammers(atk_len)
+            # Move a bit back and another round
+            self._move_and_attack((40, 20), atk_len)
             # Back to center stairs and more hammers
             self._pather.traverse_nodes([226], self, time_out=2.5, force_tp=True)
             self._cast_hammers(atk_len)
-            # move a bit to the top
+            # Move a bit to the top
             self._move_and_attack((65, -30), atk_len)
         else:
+            # Start hammers near the entrance
+            self._cast_hammers(atk_len)
+            # Go left of center stairs a bit
+            self._pather.traverse_nodes([226, 227], self, time_out=2, force_tp=True, force_move=True, do_pre_move=self._do_pre_move)
+            self._cast_hammers(atk_len)
+            # Move a bit to the top and more hammer
+            self._move_and_attack((20, 10), atk_len)
+            # Go inside and hammer a bit
+            if not self._pather.traverse_nodes([228, 229], self, time_out=2, force_tp=True, force_move=True, do_pre_move=self._do_pre_move):
+                self._move_and_attack((-5, 5), atk_len / 2)
+            self._cast_hammers(atk_len)
             # Stay inside and cast hammers again moving forward
             self._move_and_attack((40, 10), atk_len)
-            self._move_and_attack((-40, -20), atk_len)
         self._cast_hammers(1.6, "redemption")
         return True
 

--- a/src/item/pickit.py
+++ b/src/item/pickit.py
@@ -45,7 +45,7 @@ class PickIt:
         same_item_timer = None
         did_force_move = False
         while not time_out:
-            if (time.time() - start) > 28:
+            if (time.time() - start) > 22:
                 time_out = True
                 Logger.warning("Got stuck during pickit, skipping it this time...")
                 break
@@ -79,7 +79,10 @@ class PickIt:
                 found_nothing = 0
                 closest_item = item_list[0]
                 for item in item_list[1:]:
-                    if closest_item.dist > item.dist:
+                    # if we're looting Trav as a non-teleporter, we need to spend less time stuck on
+                    # stuff like gold because we're gonna be looting multiple times from a few different positions
+                    if closest_item.dist > item.dist and not \
+                        (is_at_trav and not char.can_teleport() and item.name in skip_items):
                         closest_item = item
 
                 # check if we trying to pickup the same item for a longer period of time

--- a/src/run/trav.py
+++ b/src/run/trav.py
@@ -50,13 +50,23 @@ class Trav:
             if not self._pather.traverse_nodes((Location.A3_TRAV_START, Location.A3_TRAV_CENTER_STAIRS), self._char, force_move=True):
                 return False
         self._char.kill_council()
-        picked_up_items = self._pickit.pick_up_items(self._char, is_at_trav=True)
-        wait(0.2, 0.3)
+        
         # If we can teleport we want to move back inside and also check loot there
+        picked_up_items = False
         if self._char.can_teleport():
+            picked_up_items = self._pickit.pick_up_items(self._char, is_at_trav=True)
+            wait(0.2, 0.3)
             if not self._pather.traverse_nodes([229], self._char, time_out=2.5):
                 self._pather.traverse_nodes([228, 229], self._char, time_out=2.5)
             picked_up_items |= self._pickit.pick_up_items(self._char, is_at_trav=True)
+        else: # Else we need to make sure we loot both inside and outside the council room
+            self._pather.traverse_nodes([228, 226], self._char, time_out=2, force_move=True)
+            picked_up_items |= self._pickit.pick_up_items(self._char, is_at_trav=True)
+            wait(0.2, 0.3)
+            self._pather.traverse_nodes([226, 228, 229], self._char, time_out=2, force_move=True)
+            picked_up_items |= self._pickit.pick_up_items(self._char, is_at_trav=True)
+            wait(0.2, 0.3)
+
         # Make sure we go back to the center to not hide the tp
         self._pather.traverse_nodes([230], self._char, time_out=2.5)
         return (Location.A3_TRAV_CENTER_STAIRS, picked_up_items)


### PR DESCRIPTION
The current scripting for Hammerdins without Enigma results in a large variance in how much of the council are killed, and it very frequently gets stuck looting below or above the window.

One big problem with the current script is that it would start by running all the way inside the building. Whenever the council members spawned outside, your merc would tank them all outside while you sit inside casting Hammers at nothing. These changes now begin Hammers outside, at the entrance, so that is no longer an issue. The mobs will generally come out to meet you. Afterwards, it goes into the building to clean up anyone who stayed inside.

The other big problem with the script is with looting. The wall separating the interior of the building and the outside patio area caused the bot to get stuck looting on the wall - frequently skipping half or even all of the loot. My changes now check both the inside and outside for loot in separate steps when Teleport is not available.

I made sure to split these changes out in such a way that only a non-Teleporting character will be affected.