### PR TITLE
Support multiple monitors with win32api

### DIFF
--- a/src/screen.py
+++ b/src/screen.py
@@ -25,16 +25,16 @@ class Screen:
         self._config = Config()
         self._monitor_roi = self._sct.monitors[monitor_idx]
         # auto find offests
-        self.found_offsets = False        
+        self.found_offsets = False
         position = None
         if self._config.general["find_window_via_win32_api"] :
-            Logger.debug("Using WinAPI to search for window under D2R.exe process")    
+            Logger.debug("Using WinAPI to search for window under D2R.exe process")
             position = self.find_window_via_winapi()
             if position is None:
                 Logger.debug("Can't find any window owned by D2R.exe falling back to matching via assets. Make sure D2R is in focus and you are on the hero selection screen")
-        
-        if position is None:                
-            position = self.find_window_via_assets(wait)        
+
+        if position is None:
+            position = self.find_window_via_assets(wait)
 
         if position is not None:
             self._set_window_position(*position)
@@ -44,7 +44,7 @@ class Screen:
             Logger.error("Could not find hero selection or template for ingame, shutting down")
             Logger.error("Could not determine window offset. Please make sure you have the D2R window " +
                                     f"focused and that you are on the hero selection screen when pressing {self._config.general['resume_key']}")
-    
+
     def _set_window_position(self, offset_x: int, offset_y: int):
         Logger.debug(f"Set offsets: left {offset_x}px, top {offset_y}px")
         self._monitor_roi["top"] += offset_y
@@ -55,7 +55,7 @@ class Screen:
         self._monitor_roi["height"] = self._config.ui_pos["screen_height"]
         self.found_offsets = True
 
-    
+
     def find_window_via_assets(self, wait: int) -> Tuple[int, int]:
         template = load_template(f"assets/templates/main_menu_top_left.png", 1.0)
         template_ingame = load_template(f"assets/templates/window_ingame_offset_reference.png", 1.0)
@@ -85,7 +85,7 @@ class Screen:
                     Logger.warning(f"Your template match score to calc corner was lower then usual ({max_val*100:.1f}% confidence). " +
                         "You might run into template matching issues along the way!")
                 return max_pos
-        Logger.error(f"The max score that could be found was: ({debug_max_val*100:.1f}% confidence)")        
+        Logger.error(f"The max score that could be found was: ({debug_max_val*100:.1f}% confidence)")
         return None
 
     def find_window_via_winapi(self) -> Tuple[int, int]:
@@ -93,9 +93,9 @@ class Screen:
         if position is None:
             return None
 
-        offset_x, offset_y, _, _ = position
+        offset_x, offset_y = position
         return offset_x, offset_y
-                    
+
     def convert_monitor_to_screen(self, screen_coord: Tuple[float, float]) -> Tuple[float, float]:
         return (screen_coord[0] - self._monitor_roi["left"], screen_coord[1] - self._monitor_roi["top"])
 

--- a/src/utils/misc.py
+++ b/src/utils/misc.py
@@ -12,6 +12,7 @@ from math import cos, sin, dist
 import subprocess
 from win32con import HWND_TOPMOST, SWP_NOMOVE, SWP_NOSIZE, HWND_TOP, HWND_BOTTOM, SWP_NOZORDER, SWP_NOOWNERZORDER, HWND_DESKTOP, SWP_NOSENDCHANGING, SWP_SHOWWINDOW, HWND_NOTOPMOST
 from win32gui import GetWindowText, SetWindowPos, EnumWindows, GetClientRect, ClientToScreen
+from win32api import GetMonitorInfo, MonitorFromWindow
 from win32process import GetWindowThreadProcessId
 import psutil
 
@@ -26,8 +27,10 @@ def find_d2r_window():
         for (hwnd, _, process_id) in window_list:
             if psutil.Process(process_id).name() == "D2R.exe":
                 left, top, right, bottom = GetClientRect(hwnd)
+                monitor = MonitorFromWindow(hwnd)
+                (monitor_offset_x, monitor_offset_y,_,_) = GetMonitorInfo(monitor)['Monitor']
                 (left, top), (right, bottom) = ClientToScreen(hwnd, (left, top)), ClientToScreen(hwnd, (right, bottom))
-                return (left, top, right, bottom)
+                return (left - monitor_offset_x, top - monitor_offset_y)
     return None
         
 def set_d2r_always_on_top():


### PR DESCRIPTION
- `find_window_via_win32_api=1` option only works with a single monitor setup, changes enables supporting multiple monitors
- Cleaning up some trailing whitespaces in screen.py