### PR TITLE
Fix Lightning Sorc Sometimes Exits in the middle of Nihlathak fight

### DIFF
--- a/src/char/sorceress/light_sorc.py
+++ b/src/char/sorceress/light_sorc.py
@@ -189,21 +189,33 @@ class LightSorc(Sorceress):
         # Find nilhlatak position
         delay = [0.2, 0.3]
         atk_len = int(self._char_config["atk_len_nihlatak"])
+        nihlatak_pos_abs = None
         for i in range(atk_len):
-            nihlatak_pos_abs = self._pather.find_abs_node_pos(end_nodes[-1], self._screen.grab())
-            if nihlatak_pos_abs is None:
-                return False
-            cast_pos_abs = np.array([nihlatak_pos_abs[0] * 0.9, nihlatak_pos_abs[1] * 0.9])
-            self._chain_lightning(cast_pos_abs, delay, 90)
-            # Do some tele "dancing" after each sequence
-            if i < atk_len - 1:
-                rot_deg = random.randint(-10, 10) if i % 2 == 0 else random.randint(170, 190)
-                tele_pos_abs = unit_vector(rotate_vec(cast_pos_abs, rot_deg)) * 100
-                pos_m = self._screen.convert_abs_to_monitor(tele_pos_abs)
-                self.pre_move()
-                self.move(pos_m)
+            nihlatak_pos_abs_next = self._pather.find_abs_node_pos(end_nodes[-1], self._screen.grab())
+
+            if nihlatak_pos_abs_next is not None:
+                nihlatak_pos_abs = nihlatak_pos_abs_next
             else:
-                self._lightning(cast_pos_abs, spray=60)
+                Logger.warning(f"Can't find Nihlathak next position at node {end_nodes[-1]}")
+                if nihlatak_pos_abs is not None:
+                    Logger.warning(f"Using previous position for attack sequence")
+                    
+            if nihlatak_pos_abs is not None:
+                cast_pos_abs = np.array([nihlatak_pos_abs[0] * 0.9, nihlatak_pos_abs[1] * 0.9])
+                self._chain_lightning(cast_pos_abs, delay, 90)
+                # Do some tele "dancing" after each sequence
+                if i < atk_len - 1:
+                    rot_deg = random.randint(-10, 10) if i % 2 == 0 else random.randint(170, 190)
+                    tele_pos_abs = unit_vector(rotate_vec(cast_pos_abs, rot_deg)) * 100
+                    pos_m = self._screen.convert_abs_to_monitor(tele_pos_abs)
+                    self.pre_move()
+                    self.move(pos_m)
+                else:
+                    self._lightning(cast_pos_abs, spray=60)
+            else:               
+                Logger.warning(f"Casting static as the last position isn't known. Skipping attack sequence")
+                self._cast_static(duration=2)
+
         # Move to items
         wait(self._cast_duration, self._cast_duration + 0.2)
         self._pather.traverse_nodes(end_nodes, self, time_out=0.8)


### PR DESCRIPTION
The line below doesn't always succeeds (could be due to a pack of mobs blocking the view) and botty just exits the game in this case which leads to failed run. I would've failed ~25 runs out of 145 last night if I didn't have this fix
```python
self._pather.find_abs_node_pos(end_nodes[-1], self._screen.grab())
```
Blizzard sorc also doesn't exits in case above returns None and just carries on. I've opted to cast static to get some potential value and add a wait before trying again

Attaching logs from last night
[logs.txt](https://github.com/aeon0/botty/files/7965270/logs.txt)