### PR TITLE
Added exception handling to Discord API calls

### DIFF
--- a/src/messages/discord_embeds.py
+++ b/src/messages/discord_embeds.py
@@ -1,19 +1,21 @@
 from .generic_api import GenericApi
 from config import Config
+from logger import Logger
 import cv2
 import datetime
 import traceback
 import discord
 from version import __version__
 import numpy as np
-from discord import Webhook, RequestsWebhookAdapter, Color
+from discord import Webhook, RequestsWebhookAdapter, Color, InvalidArgument
 
 class DiscordEmbeds(GenericApi):
     def __init__(self):
         self._config = Config()
-        self._webhook = Webhook.from_url(self._config.general['custom_message_hook'], adapter=RequestsWebhookAdapter(), )
-        self._file = None
-        self._psnURL = "https://i.psnprofiles.com/games/3bffee/trophies/"
+        try:
+            self._webhook = Webhook.from_url(self._config.general['custom_message_hook'], adapter=RequestsWebhookAdapter(), )
+        except InvalidArgument:
+            Logger.warning(f"Your custom_message_hook URL {self._config.general['custom_message_hook']} is invalid, Discord updates will not be sent")
 
     def send_item(self, item: str, image:  np.ndarray, location: str):
         imgName = item.replace('_', '-')
@@ -73,8 +75,10 @@ class DiscordEmbeds(GenericApi):
     def _send_embed(self, e, file = None):
         e.set_footer(text=f'Botty v.{__version__} by Aeon')
         e.timestamp=datetime.datetime.now(datetime.timezone.utc)
-
-        self._webhook.send(embed=e, file=file, username=self._config.general['name'])
+        try:
+            self._webhook.send(embed=e, file=file, username=self._config.general['name'])
+        except BaseException as err:
+            Logger.error("Error sending Discord embed: " + err)
 
     def _get_Item_Color(self, item):
         if "magic_" in item:

--- a/src/messages/discord_embeds.py
+++ b/src/messages/discord_embeds.py
@@ -12,6 +12,8 @@ from discord import Webhook, RequestsWebhookAdapter, Color, InvalidArgument
 class DiscordEmbeds(GenericApi):
     def __init__(self):
         self._config = Config()
+        self._file = None
+        self._psnURL = "https://i.psnprofiles.com/games/3bffee/trophies/"
         try:
             self._webhook = Webhook.from_url(self._config.general['custom_message_hook'], adapter=RequestsWebhookAdapter(), )
         except InvalidArgument:

--- a/src/messages/generic_api.py
+++ b/src/messages/generic_api.py
@@ -47,4 +47,4 @@ class GenericApi:
         try:
             requests.post(url, headers=headers, json=data)
         except BaseException as err:
-            Logger.error("Error sending generic Discord message: " + err)
+            Logger.error("Error sending generic message: " + err)

--- a/src/messages/generic_api.py
+++ b/src/messages/generic_api.py
@@ -1,4 +1,5 @@
 from config import Config
+from logger import Logger
 import numpy as np
 import json
 import requests
@@ -32,6 +33,7 @@ class GenericApi:
 
     def _send(self, msg: str):
         msg = f"{self._config.general['name']}: {msg}"
+        
         url = self._config.general['custom_message_hook']
         if not url:
             return
@@ -42,4 +44,7 @@ class GenericApi:
 
         data = json.loads(self._config.advanced_options['message_body_template'].format(msg=msg), strict=False)
 
-        requests.post(url, headers=headers, json=data)
+        try:
+            requests.post(url, headers=headers, json=data)
+        except BaseException as err:
+            Logger.error("Error sending generic Discord message: " + err)


### PR DESCRIPTION
Last week when Discord's servers were down, I discovered that there were uncaught exceptions being thrown in the Discord API logic that caused Botty to crash, I was botting on a Hardcore character at the time, and this left my character standing in-game at the Waypoint without Botty running (no chicken). This could cause a Hardcore death.

This PR added exception handling to the Discord API calls that have the potential to throw exceptions, possibly preventing unnecessary deaths in the event of a Discord outage or Discord Webhook configuration errors.