### PR TITLE
Fix character stuck trying to teleport in town

### DIFF
--- a/src/char/i_char.py
+++ b/src/char/i_char.py
@@ -133,7 +133,7 @@ class IChar:
 
     def move(self, pos_monitor: Tuple[float, float], force_tp: bool = False, force_move: bool = False):
         factor = self._config.advanced_options["pathing_delay_factor"]
-        if self._skill_hotkeys["teleport"] and (force_tp or self._ui_manager.is_right_skill_selected(["TELE_ACTIVE"])):
+        if self._skill_hotkeys["teleport"] and (force_tp or (self._ui_manager.is_right_skill_selected(["TELE_ACTIVE"]) and self._ui_manager.is_right_skill_active())):
             mouse.move(pos_monitor[0], pos_monitor[1], randomize=3, delay_factor=[factor*0.1, factor*0.14])
             wait(0.012, 0.02)
             mouse.click(button="right")


### PR DESCRIPTION
Most likely a merge issue as it was fixed at some point throughout 
#476

For some reason
```python
self._ui_manager.is_right_skill_selected(["TELE_ACTIVE"])
```
is returning true when Teleport is inactive in town.