### PR TITLE
Fix game isn't restarted when in main menu / character selection screen

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -210,6 +210,7 @@ class Bot:
         return result
 
     def on_init(self):
+        self._game_stats.log_start_game()
         keyboard.release(self._config.char["stand_still"])
         transition_to_screens = Bot._rebuild_as_asset_to_trigger({
             "select_character": Bot._MAIN_MENU_MARKERS,
@@ -236,7 +237,6 @@ class Bot:
         self.trigger_or_stop("start_from_town")
 
     def on_start_from_town(self):
-        self._game_stats.log_start_game()
         self._curr_loc = self._town_manager.wait_for_town_spawn()
         # Check for the current game ip and pause if we are able to obtain the hot ip
         if self._config.dclone["region_ips"] != "" and self._config.dclone["dclone_hotip"] != "":

--- a/src/utils/restart.py
+++ b/src/utils/restart.py
@@ -1,6 +1,8 @@
 import subprocess
 import os, sys
 import keyboard
+from bot import Bot
+from template_finder import TemplateFinder
 from utils.misc import wait, set_d2r_always_on_top
 from screen import Screen
 from config import Config
@@ -38,11 +40,15 @@ def restart_game(d2_path = None):
     set_d2r_always_on_top()
     while not success:
         screen = Screen()
-        success = screen.found_offsets
-        if not success:
-            keyboard.send("space")
-            wait(0.2, 0.4)
-            attempts += 1
+        success = screen.found_offsets        
+        wait(0.5, 1.0)
+
+    template_finder = TemplateFinder(screen)
+    
+    while not template_finder.search(Bot._MAIN_MENU_MARKERS,screen.grab(), best_match=True).valid:
+        keyboard.send("space")
+        wait(2.0, 4.0)
+        attempts += 1
         if attempts >= 5:
             return False
     return True
@@ -50,6 +56,8 @@ def restart_game(d2_path = None):
 # For testing 
 if __name__ == "__main__":
     if len(sys.argv) > 1:
-        restart_game(sys.argv[1])
+        result = restart_game(sys.argv[1])
+        print(result)
     else:
-        restart_game()
+        result = restart_game()
+        print(result)


### PR DESCRIPTION
1) game isn't being tracked up until start_from_town which means max_game_length_s isn't accounted for during character selection
2) restart_game utility isn't handling new screen behavior properly and depending on it to wait for main menu while it's not