### PR TITLE
Fix running graphic_debugger.py as a standalone process

### DIFF
--- a/src/utils/graphic_debugger.py
+++ b/src/utils/graphic_debugger.py
@@ -348,5 +348,5 @@ class GraphicDebuggerController:
             cv2.waitKey(1)
 
 if __name__ == "__main__":
-    debugger = GraphicDebuggerController(Config())
+    debugger = GraphicDebuggerController()
     debugger.start()


### PR DESCRIPTION
GraphicDebuggerController constructor no longer takes any arguments