### PR TITLE
Skip Transmuting if Cube isn't empty

### DIFF
--- a/src/transmute/transmute.py
+++ b/src/transmute/transmute.py
@@ -196,15 +196,29 @@ class Transmute:
             return None
         self._run_gem_transmutes()
 
+    def check_cube_empty(self) -> bool:
+        self.open_cube()
+        area = self.inspect_cube()
+        self.close_cube()
+        return area.count_empty() == 12
+
+    def inspect_cube(self)-> InventoryCollection:
+        return self.inspect_area(4, 3, roi=Config.ui_roi["cube_area_roi"], known_items=FLAWLESS_GEMS)
+    
     def _run_gem_transmutes(self) -> None:
         Logger.info("Starting gem transmute")
         self._last_game = self._game_stats._game_counter
         s = self.inspect_stash()
         algorithm = SimpleGemPicking(s)
         inventory = self.inspect_inventory_area(FLAWLESS_GEMS)
+        is_cube_empty = None
         while True:
             while inventory.count_empty() >= 3:
-                next_batch = algorithm.next_batch()
+                next_batch = algorithm.next_batch()                
+                is_cube_empty = self.check_cube_empty() if is_cube_empty is None else is_cube_empty
+                if not is_cube_empty:
+                    Logger.warning("Some items detected in the cube. Skipping transmute")
+                    break
                 if next_batch is None:
                     Logger.info("No more gems to cube")
                     break


### PR DESCRIPTION
If cube isn't empty transmute would do god knows what. So checking fist the cube before picking gems. Trying to check the cube only when we know that there are gems to transmute.
