### PR TITLE
Track nopickup status in GameStats and only /nopickup once

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -252,10 +252,10 @@ class Bot:
                 Logger.info(f"Please Enter the region ip and hot ip on config to use")
 
         # Run /nopickup command to avoid picking up stuff on accident
-        if not self._ran_no_pickup and not self._game_stats._nopick_active:
+        if not self._ran_no_pickup and not self._game_stats._nopickup_active:
             self._ran_no_pickup = True
             if self._ui_manager.enable_no_pickup():
-                self._game_stats._nopick_active = True
+                self._game_stats._nopickup_active = True
                 Logger.info("Activated /nopickup")
             else:
                 Logger.error("Failed to detect if /nopickup command was applied or not")

--- a/src/bot.py
+++ b/src/bot.py
@@ -252,9 +252,10 @@ class Bot:
                 Logger.info(f"Please Enter the region ip and hot ip on config to use")
 
         # Run /nopickup command to avoid picking up stuff on accident
-        if not self._ran_no_pickup:
+        if not self._ran_no_pickup and not self._game_stats._nopick_active:
             self._ran_no_pickup = True
             if self._ui_manager.enable_no_pickup():
+                self._game_stats._nopick_active = True
                 Logger.info("Activated /nopickup")
             else:
                 Logger.error("Failed to detect if /nopickup command was applied or not")

--- a/src/game_stats.py
+++ b/src/game_stats.py
@@ -31,6 +31,7 @@ class GameStats:
         self._location_stats = {}
         self._location_stats["totals"] = { "items": 0, "deaths": 0, "chickens": 0, "merc_deaths": 0, "failed_runs": 0 }
         self._stats_filename = f'stats_{time.strftime("%Y%m%d_%H%M%S")}.log'
+        self._nopick_active = False
 
     def update_location(self, loc: str):
         if self._location != loc:

--- a/src/game_stats.py
+++ b/src/game_stats.py
@@ -31,7 +31,7 @@ class GameStats:
         self._location_stats = {}
         self._location_stats["totals"] = { "items": 0, "deaths": 0, "chickens": 0, "merc_deaths": 0, "failed_runs": 0 }
         self._stats_filename = f'stats_{time.strftime("%Y%m%d_%H%M%S")}.log'
-        self._nopick_active = False
+        self._nopickup_active = False
 
     def update_location(self, loc: str):
         if self._location != loc:


### PR DESCRIPTION
While the initial code was more resilient, this approach aims to:
* Reduce visual noise (if you're watching the bot)
* Reduce possible behavioral pattern detection