### PR TITLE
Bugfix: Save/exit error

### DIFF
--- a/src/screen.py
+++ b/src/screen.py
@@ -18,24 +18,39 @@ detect_window = True
 
 def convert_monitor_to_screen(screen_coord: Tuple[float, float]) -> Tuple[float, float]:
     global monitor_roi
+    if screen_coord is None:
+        Logger.error("convert_monitor_to_screen: empty coordinates passed")
+        return None
     return (screen_coord[0] - monitor_roi["left"], screen_coord[1] - monitor_roi["top"])
 
 def convert_screen_to_monitor(screen_coord: Tuple[float, float]) -> Tuple[float, float]:
     global monitor_roi
+    if screen_coord is None:
+        Logger.error("convert_screen_to_monitor: empty coordinates passed")
+        return None
     x = screen_coord[0] + monitor_roi["left"]
     y = screen_coord[1] + monitor_roi["top"]
     return (np.clip(x, *monitor_x_range), np.clip(y, *monitor_y_range))
 
 def convert_abs_to_screen(abs_coord: Tuple[float, float]) -> Tuple[float, float]:
     global monitor_roi
+    if abs_coord is None:
+        Logger.error("convert_screen_to_monitor: empty coordinates passed")
+        return None
     # abs has it's center on char which is the center of the screen
     return ((monitor_roi["width"] // 2) + abs_coord[0], (monitor_roi["height"] // 2) + abs_coord[1])
 
 def convert_screen_to_abs(screen_coord: Tuple[float, float]) -> Tuple[float, float]:
     global monitor_roi
+    if screen_coord is None:
+        Logger.error("convert_screen_to_abs: empty coordinates passed")
+        return None
     return (screen_coord[0] - (monitor_roi["width"] // 2), screen_coord[1] - (monitor_roi["height"] // 2))
 
 def convert_abs_to_monitor(abs_coord: Tuple[float, float]) -> Tuple[float, float]:
+    if abs_coord is None:
+        Logger.error("convert_abs_to_monitor: empty coordinates passed")
+        return None
     screen_coord = convert_abs_to_screen(abs_coord)
     monitor_coord = convert_screen_to_monitor(screen_coord)
     return monitor_coord

--- a/src/ui_components/view.py
+++ b/src/ui_components/view.py
@@ -34,41 +34,19 @@ def enable_no_pickup() -> bool:
     wait(0.1, 0.25)
     return True
 
-def check_save_exit(img: np.ndarray = None):
-    img = grab() if img is None else img
-    return detect_screen_object(ScreenObjects.SaveAndExit, img)
-
-def open_save_exit():
-    keyboard.send("esc")
-    wait(0.1)
-    return check_save_exit()
-
-def click_save_exit(match):
-    select_screen_object_match(match, delay_factor=(0.1, 0.3))
-    wait(0.1)
-    return not check_save_exit()
-
-def save_and_exit(img: np.ndarray = None) -> bool:
+def save_and_exit() -> bool:
     """
     Performes save and exit action from within game
     :return: Bool if action was successful
     """
-    # see if save/exit already on screen
-    exit_button = check_save_exit(img)
-    if not exit_button.valid:
-        # if not on screen, open
-        if not (exit_button := open_save_exit()):
+    start=time.time()
+    while not (exit_button := detect_screen_object(ScreenObjects.SaveAndExit)).valid:
+        keyboard.send("esc")
+        wait(0.1)
+        if time.time() - start > 5:
             return False
-    # if clicked and the save/exit screen is no longer visible
-    if click_save_exit(exit_button):
-        return True
-    # try one more time
-    else:
-        wait(0.6, 1)
-        if click_save_exit(exit_button):
-            return True
-    wait(1, 2)
-    return not check_save_exit()
+    select_screen_object_match(exit_button, delay_factor=(0.1, 0.3))
+    return True
 
 def pickup_corpse():
     Logger.info("Pickup corpse")


### PR DESCRIPTION
Fix bug where save/exit routine would pass an empty template match

```
  File "C:\Users\Botty\code\botty\src\bot.py", line 369, in on_end_game
    view.save_and_exit()
  File "C:\Users\Botty\code\botty\src\ui_components\view.py", line 63, in save_and_exit
    if click_save_exit(exit_button):
  File "C:\Users\Botty\code\botty\src\ui_components\view.py", line 47, in click_save_exit
    select_screen_object_match(match, delay_factor=(0.1, 0.3))
  File "C:\Users\Botty\code\botty\src\ui\ui_manager.py", line 202, in select_screen_object_match
    mouse.move(*convert_screen_to_monitor(match.center), delay_factor=delay_factor)
  File "C:\Users\Botty\code\botty\src\screen.py", line 25, in convert_screen_to_monitor
    x = screen_coord[0] + monitor_roi["left"]
TypeError: 'NoneType' object is not subscriptable
```