### PR TITLE
Remove: Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,3 @@ jobs:
         run: |
           C:\Miniconda\condabin\conda.bat activate botty
           coverage xml
-      - name: Upload Coverage to Codecov
-        uses: codecov/codecov-action@v2
-        with:
-          verbose: true
-          files: ./coverage.xml

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,0 @@
-comment: false

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+# random comment

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,0 @@
-# random comment


### PR DESCRIPTION
Removing the codecov reporting since it is bound to my account and might cause some issues or at least is not nice to the eye to have a few red x on the PR :)
Leaving the coverage report generation just to keep that info available for anybody interested.