### PR TITLE
Bugfix/refactor: Arcane run doesn't turn off health_monitor when in town

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -8,6 +8,7 @@ import cv2
 from copy import copy
 from typing import Union
 from collections import OrderedDict
+from health_manager import set_pause_state
 from transmute import Transmute
 
 from utils.misc import wait
@@ -251,6 +252,9 @@ class Bot:
         self.trigger_or_stop("maintenance")
 
     def on_maintenance(self):
+        # Pause health manager if not already paused
+        set_pause_state(True)
+
         # Dismiss skill/quest/help/stats icon if they are on screen
         if not view.dismiss_skills_icon():
             view.return_to_play()
@@ -395,6 +399,7 @@ class Bot:
         self._curr_loc = False
         self._pre_buffed = False
         view.save_and_exit()
+        set_pause_state(True)
         self._game_stats.log_end_game(failed=failed)
         self._do_runs = copy(self._do_runs_reset)
         if Config().general["randomize_runs"]:
@@ -408,9 +413,11 @@ class Bot:
         if success:
             self._curr_loc = self._town_manager.wait_for_tp(self._curr_loc)
             if self._curr_loc:
+                set_pause_state(True)
                 return self.trigger_or_stop("maintenance")
         if not skills.has_tps():
             consumables.set_needs("tp", 20)
+        set_pause_state(True)
         self.trigger_or_stop("end_game", failed=True)
 
     # All the runs go here
@@ -436,6 +443,7 @@ class Bot:
         self._game_stats.update_location("Pin" if Config().general['discord_status_condensed'] else "Pindle")
         self._curr_loc = self._pindle.approach(self._curr_loc)
         if self._curr_loc:
+            set_pause_state(False)
             res = self._pindle.battle(not self._pre_buffed)
         self._ending_run_helper(res)
 
@@ -444,6 +452,7 @@ class Bot:
         self._do_runs["run_shenk"] = False
         self._curr_loc = self._shenk.approach(self._curr_loc)
         if self._curr_loc:
+            set_pause_state(False)
             res = self._shenk.battle(Config().routes["run_shenk"], not self._pre_buffed, self._game_stats)
         self._ending_run_helper(res)
 
@@ -453,6 +462,7 @@ class Bot:
         self._game_stats.update_location("Trav" if Config().general['discord_status_condensed'] else "Travincal")
         self._curr_loc = self._trav.approach(self._curr_loc)
         if self._curr_loc:
+            set_pause_state(False)
             res = self._trav.battle(not self._pre_buffed)
         self._ending_run_helper(res)
 
@@ -462,6 +472,7 @@ class Bot:
         self._game_stats.update_location("Nihl" if Config().general['discord_status_condensed'] else "Nihlathak")
         self._curr_loc = self._nihlathak.approach(self._curr_loc)
         if self._curr_loc:
+            set_pause_state(False)
             res = self._nihlathak.battle(not self._pre_buffed)
         self._ending_run_helper(res)
 
@@ -471,6 +482,7 @@ class Bot:
         self._game_stats.update_location("Arc" if Config().general['discord_status_condensed'] else "Arcane")
         self._curr_loc = self._arcane.approach(self._curr_loc)
         if self._curr_loc:
+            set_pause_state(False)
             res = self._arcane.battle(not self._pre_buffed)
         self._ending_run_helper(res)
 
@@ -480,5 +492,6 @@ class Bot:
         self._game_stats.update_location("Dia" if Config().general['discord_status_condensed'] else "Diablo")
         self._curr_loc = self._diablo.approach(self._curr_loc)
         if self._curr_loc:
+            set_pause_state(False)
             res = self._diablo.battle(not self._pre_buffed)
         self._ending_run_helper(res)

--- a/src/game_controller.py
+++ b/src/game_controller.py
@@ -42,7 +42,6 @@ class GameController:
         do_restart = False
         messenger = Messenger()
         while 1:
-            self.health_manager.update_location(self.bot.get_curr_location())
             max_game_length_reached = self.game_stats.get_current_game_length() > Config().general["max_game_length_s"]
             max_consecutive_fails_reached = False if not Config().general["max_consecutive_fails"] else self.game_stats.get_consecutive_runs_failed() >= Config().general["max_consecutive_fails"]
             if max_game_length_reached or max_consecutive_fails_reached or self.death_manager.died() or self.health_manager.did_chicken():

--- a/src/health_manager.py
+++ b/src/health_manager.py
@@ -13,6 +13,20 @@ from inventory import common
 from ui import view, meters
 from ui_manager import detect_screen_object, ScreenObjects
 
+pause_state = True
+
+def get_pause_state():
+    global pause_state
+    return pause_state
+
+def set_pause_state(state: bool):
+    global pause_state
+    prev = get_pause_state()
+    if prev != state:
+        debug_str = "pausing" if state else "active"
+        Logger.info(f"Health Manager is now {debug_str}")
+        pause_state = state
+
 class HealthManager:
     def __init__(self):
         self._do_monitor = False
@@ -22,7 +36,6 @@ class HealthManager:
         self._last_mana = time.time()
         self._last_merc_heal = time.time()
         self._callback = None
-        self._pausing = True
         self._last_chicken_screenshot = None
         self._count_panel_detects = 0
 
@@ -37,16 +50,7 @@ class HealthManager:
 
     def reset_chicken_flag(self):
         self._did_chicken = False
-        self._pausing = True
-
-    def update_location(self, loc: Location):
-        if loc is not None and type(loc) == str:
-            bosses = ["shenk", "eldritch", "pindle", "nihlathak", "trav", "arc", "diablo"]
-            prev_value = self._pausing
-            self._pausing = not any(substring in loc for substring in bosses)
-            if self._pausing != prev_value:
-                debug_str = "pausing" if self._pausing else "active"
-                Logger.info(f"Health Manager is now {debug_str}")
+        set_pause_state(True)
 
     def _do_chicken(self, img):
         if self._callback is not None:
@@ -66,7 +70,7 @@ class HealthManager:
         time.sleep(0.01)
         view.save_and_exit()
         self._did_chicken = True
-        self._pausing = True
+        set_pause_state(True)
 
     def start_monitor(self):
         Logger.info("Start health monitoring")
@@ -76,7 +80,7 @@ class HealthManager:
         while self._do_monitor:
             time.sleep(0.1)
             # Wait until the flag is reset by main.py
-            if self._did_chicken or self._pausing: continue
+            if self._did_chicken or get_pause_state(): continue
             img = grab()
             if detect_screen_object(ScreenObjects.InGame, img).valid:
                 health_percentage = meters.get_health(img)
@@ -128,14 +132,15 @@ class HealthManager:
         Logger.debug("Stop health monitoring")
 
 
-# Testing: Start dying or lossing mana and see if it works
+# Testing: Start dying or losing mana and see if it works
 if __name__ == "__main__":
     import threading
     import keyboard
     import os
+    from health_manager import set_pause_state
     keyboard.add_hotkey('f12', lambda: Logger.info('Exit Health Manager') or os._exit(1))
     manager = HealthManager()
-    manager._pausing = False
+    set_pause_state(True)
     Logger.info("Press f12 to exit health manager")
     health_monitor_thread = threading.Thread(target=manager.start_monitor)
     health_monitor_thread.start()


### PR DESCRIPTION
Moved the `self._pausing` variable out of the health_manager.py class (Hey @Ezro look what I did lol) and made it a global. Can now set the pause state of health_manager.py status from anywhere, including from within arcane.py during towning routine.

This fixes a bug recently introduced in #631 in which I started using health_manager to close inventory panels should they appear during a run. This unmasked the fact that health monitor remained active during arcane run when it would be towning and consequently cause it to error when opening the waypoint menu.