### PR TITLE
Bugfix: Stash tab counts not tracking

### DIFF
--- a/src/inventory/personal.py
+++ b/src/inventory/personal.py
@@ -84,7 +84,8 @@ def stash_all_items(items: list = None):
                     Logger.error("stash_all_items(): deposit button not detected, failed to stash gold")
                 # move cursor away from button to interfere with screen grab
                 mouse.move(-120, 0, absolute=False, randomize=15, delay_factor=[0.3, 0.5])
-                stash_full_of_gold = wait_until_visible(ScreenObjects.GoldNone, 1.5).valid
+                # if 0 gold becomes visible in personal inventory then the stash tab still has room for gold
+                stash_full_of_gold = not wait_until_visible(ScreenObjects.GoldNone, 1.5).valid
             if stash_full_of_gold:
                 Logger.debug("Stash tab is full of gold, selecting next stash tab.")
                 stash.set_curr_stash(gold = (stash.get_curr_stash()["gold"] + 1))

--- a/src/inventory/personal.py
+++ b/src/inventory/personal.py
@@ -68,7 +68,7 @@ def stash_all_items(items: list = None):
     if Config().char["stash_gold"]:
         if not is_visible(ScreenObjects.GoldNone):
             Logger.debug("Stashing gold")
-            stash.move_to_stash_tab(min(3, stash.curr_stash["gold"]))
+            common.select_tab(min(3, stash.get_curr_stash()["gold"]))
             wait(0.7, 1)
             stash_full_of_gold = False
             # Try to read gold count with OCR
@@ -87,10 +87,10 @@ def stash_all_items(items: list = None):
                 stash_full_of_gold = wait_until_visible(ScreenObjects.GoldNone, 1.5).valid
             if stash_full_of_gold:
                 Logger.debug("Stash tab is full of gold, selecting next stash tab.")
-                stash.curr_stash["gold"] += 1
+                stash.set_curr_stash(gold = (stash.get_curr_stash()["gold"] + 1))
                 if Config().general["info_screenshots"]:
                     cv2.imwrite("./info_screenshots/info_gold_stash_full_" + time.strftime("%Y%m%d_%H%M%S") + ".png", grab())
-                if stash.curr_stash["gold"] > 3:
+                if stash.get_curr_stash()["gold"] > 3:
                     #decide if gold pickup should be disabled or gambling is active
                     vendor.set_gamble_status(True)
                 else:
@@ -99,8 +99,8 @@ def stash_all_items(items: list = None):
             else:
                 set_inventory_gold_full(False)
     # check if stash tab is completely full (no empty slots)
-    stash.move_to_stash_tab(stash.curr_stash["items"])
-    while stash.curr_stash["items"] <= 3:
+    common.select_tab(stash.get_curr_stash()["items"])
+    while stash.get_curr_stash()["items"] <= 3:
         img = grab()
         if is_visible(ScreenObjects.EmptyStashSlot, img):
             break
@@ -108,10 +108,13 @@ def stash_all_items(items: list = None):
             Logger.debug(f"Stash tab completely full, advance to next")
             if Config().general["info_screenshots"]:
                 cv2.imwrite("./info_screenshots/stash_tab_completely_full_" + time.strftime("%Y%m%d_%H%M%S") + ".png", img)
-            stash.curr_stash["items"] += -1 if Config().char["fill_shared_stash_first"] else 1
-            if (Config().char["fill_shared_stash_first"] and stash.curr_stash["items"] < 0) or stash.curr_stash["items"] > 3:
+            if Config().char["fill_shared_stash_first"]:
+                stash.set_curr_stash(items = (stash.get_curr_stash()["items"] - 1))
+            else:
+                stash.set_curr_stash(items = (stash.get_curr_stash()["items"] + 1))
+            if (Config().char["fill_shared_stash_first"] and stash.get_curr_stash()["items"] < 0) or stash.get_curr_stash()["items"] > 3:
                 stash.stash_full()
-            stash.move_to_stash_tab(stash.curr_stash["items"])
+            common.select_tab(stash.get_curr_stash()["items"])
     # stash stuff
     while True:
         items = common.transfer_items(items, "stash")
@@ -120,10 +123,13 @@ def stash_all_items(items: list = None):
             Logger.debug("Wanted to stash item, but it's still in inventory. Assumes full stash. Move to next.")
             if Config().general["info_screenshots"]:
                 cv2.imwrite("./info_screenshots/debug_info_inventory_not_empty_" + time.strftime("%Y%m%d_%H%M%S") + ".png", grab())
-            stash.curr_stash["items"] += -1 if Config().char["fill_shared_stash_first"] else 1
-            if (Config().char["fill_shared_stash_first"] and stash.curr_stash["items"] < 0) or stash.curr_stash["items"] > 3:
+            if Config().char["fill_shared_stash_first"]:
+                stash.set_curr_stash(items = (stash.get_curr_stash()["items"] - 1))
+            else:
+                stash.set_curr_stash(items = (stash.get_curr_stash()["items"] + 1))
+            if (Config().char["fill_shared_stash_first"] and stash.get_curr_stash()["items"] < 0) or stash.get_curr_stash()["items"] > 3:
                 stash.stash_full()
-            stash.move_to_stash_tab(stash.curr_stash["items"])
+            common.select_tab(stash.get_curr_stash()["items"])
         else:
             break
     Logger.debug("Done stashing")

--- a/src/inventory/stash.py
+++ b/src/inventory/stash.py
@@ -28,21 +28,3 @@ def stash_full():
     os.system("taskkill /f /im  D2R.exe")
     wait(1.0, 1.5)
     os._exit(0)
-
-def move_to_stash_tab(stash_idx: int):
-    """Move to a specifc tab in the stash
-    :param stash_idx: idx of the stash starting at 0 (personal stash)
-    """
-    str_to_idx_map = {"STASH_0_ACTIVE": 0, "STASH_1_ACTIVE": 1, "STASH_2_ACTIVE": 2, "STASH_3_ACTIVE": 3}
-    template_match = TemplateFinder().search([*str_to_idx_map], grab(), threshold=0.7, best_match=True, roi=Config().ui_roi["stash_btn_roi"])
-    curr_active_stash = str_to_idx_map[template_match.name] if template_match.valid else -1
-    if curr_active_stash != stash_idx:
-        # select the start stash
-        personal_stash_pos = (Config().ui_pos["stash_personal_btn_x"], Config().ui_pos["stash_personal_btn_y"])
-        stash_btn_width = Config().ui_pos["stash_btn_width"]
-        next_stash_pos = (personal_stash_pos[0] + stash_btn_width * stash_idx, personal_stash_pos[1])
-        x_m, y_m = convert_screen_to_monitor(next_stash_pos)
-        mouse.move(x_m, y_m, randomize=[30, 7], delay_factor=[1.0, 1.5])
-        wait(0.2, 0.3)
-        mouse.click(button="left")
-        wait(0.3, 0.4)

--- a/src/inventory/stash.py
+++ b/src/inventory/stash.py
@@ -12,6 +12,15 @@ curr_stash = {
     "gold": 0
 }
 
+def get_curr_stash() -> dict:
+    global curr_stash
+    return curr_stash
+
+def set_curr_stash(items: int, gold: int):
+    global curr_stash
+    if items: curr_stash["items"] = items
+    if gold: curr_stash["gold"] = gold
+
 def stash_full():
     Logger.error("All stash is full, quitting")
     if Config().general["custom_message_hook"]:

--- a/src/inventory/stash.py
+++ b/src/inventory/stash.py
@@ -16,10 +16,10 @@ def get_curr_stash() -> dict:
     global curr_stash
     return curr_stash
 
-def set_curr_stash(items: int, gold: int):
+def set_curr_stash(items: int = None, gold: int = None):
     global curr_stash
-    if items: curr_stash["items"] = items
-    if gold: curr_stash["gold"] = gold
+    if items is not None: curr_stash["items"] = items
+    if gold is not None: curr_stash["gold"] = gold
 
 def stash_full():
     Logger.error("All stash is full, quitting")

--- a/src/inventory/vendor.py
+++ b/src/inventory/vendor.py
@@ -90,7 +90,8 @@ def gamble():
         Logger.debug(f"Finish gambling")
         stash.set_curr_stash(gold = 0)
         personal.set_inventory_gold_full(False)
-        set_gamble_status(False)
+        if get_gamble_status():
+            set_gamble_status(False)
         common.close()
         return None
     else:

--- a/src/inventory/vendor.py
+++ b/src/inventory/vendor.py
@@ -8,7 +8,7 @@ from screen import grab
 from logger import Logger
 from utils.custom_mouse import mouse
 from ui_manager import is_visible, select_screen_object_match, wait_until_visible, ScreenObjects
-from inventory import personal, common
+from inventory import personal, common, stash
 
 gamble_count = 0
 gamble_status = False
@@ -88,6 +88,7 @@ def gamble():
                 if new_count >= max_gamble_count:
                     break
         Logger.debug(f"Finish gambling")
+        stash.set_curr_stash(gold = 0)
         personal.set_inventory_gold_full(False)
         set_gamble_status(False)
         common.close()

--- a/src/transmute/transmute.py
+++ b/src/transmute/transmute.py
@@ -15,8 +15,7 @@ from template_finder import TemplateFinder
 import numpy as np
 import keyboard
 import cv2
-from inventory import personal
-from inventory.stash import move_to_stash_tab
+from inventory import personal, common
 
 FLAWLESS_GEMS = [
     "INVENTORY_TOPAZ_FLAWLESS",
@@ -66,7 +65,7 @@ class Transmute:
         self._wait()
 
     def open_cube(self):
-        move_to_stash_tab(0)
+        common.select_tab(0)
         if (match := detect_screen_object(ScreenObjects.CubeInventory)).valid:
             mouse.move(*match.center)
             self._wait()
@@ -93,7 +92,7 @@ class Transmute:
         return self.pick_from_area(column, row, Config().ui_roi["right_inventory"])
 
     def pick_from_stash_at(self, index, column, row):
-        move_to_stash_tab(index)
+        common.select_tab(index)
         return self.pick_from_area(column, row, Config().ui_roi["left_inventory"])
 
     def inspect_area(self, total_rows, total_columns, roi, known_items) -> InventoryCollection:
@@ -127,7 +126,7 @@ class Transmute:
     def inspect_stash(self) -> Stash:
         stash = Stash()
         for i in range(4):
-            move_to_stash_tab(i)
+            common.select_tab(i)
             wait(0.4, 0.5)
             tab = self.inspect_area(
                 10, 10, Config().ui_roi["left_inventory"], FLAWLESS_GEMS)
@@ -141,14 +140,14 @@ class Transmute:
             while flawless_gems.count_by(gem) > 0:
                 pick.append((randint(0, 3), *flawless_gems.pop(gem)))
         for tab, x, y in sorted(pick, key=lambda x: x[0]):
-            move_to_stash_tab(tab)
+            common.select_tab(tab)
             self.pick_from_inventory_at(x, y)
 
     def select_tab_with_enough_space(self, s: Stash) -> None:
         tabs_priority = Config()._transmute_config["stash_destination"]
         for tab in tabs_priority:
             if s.get_empty_on_tab(tab) > 0:
-                move_to_stash_tab(tab)
+                common.select_tab(tab)
                 break
 
     def put_back_all_gems(self, s: Stash) -> None:


### PR DESCRIPTION
Changed curr_stash dict variable in stash.py to be a global with getter and setter. I believe this manifested as excessively frequent gambling and gold stashing. I think the curr_stash dict wasn't properly updating. Testing overnight to make sure it correctly fixes.

Got rid of old `move_to_stash_tab()` function as it was made obsolete by `common.select_tab()`

Eventually found all I probably really needed all along was in [779b548](https://github.com/aeon0/botty/pull/646/commits/779b54824cbbbd827c52b96e6de96d349d5b7546) but I think the other changes are reasonable. 