### PR TITLE
added error handling for custom.ini when missing section header

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -180,7 +180,10 @@ class Config:
         self._shop_config.read('config/shop.ini')
         self._custom = configparser.ConfigParser()
         if os.environ.get('RUN_ENV') != "test" and os.path.exists('config/custom.ini'):
-            self._custom.read('config/custom.ini')
+            try:
+                self._custom.read('config/custom.ini')
+            except configparser.MissingSectionHeaderError:
+                Logger.error("custom.ini missing section header, defaulting to params.ini")
 
         self.general = {
             "saved_games_folder": self._select_val("general", "saved_games_folder"),


### PR DESCRIPTION
I had to record & slow down a video to see the error message since the cli closed so quickly due to a missing section header in the custom.ini. this fix it..