### PR TITLE
Quick list manipulation to remove anything before experience in the list

### DIFF
--- a/src/game_stats.py
+++ b/src/game_stats.py
@@ -184,7 +184,6 @@ class GameStats:
                 msg += f'\nGames Needed To Level: {math.ceil(games_to_lvl):,}'
             except:
                 Logger.warning("Failed to log exp")
-                pass
 
         table = BeautifulTable()
         table.set_style(BeautifulTable.STYLE_BOX_ROUNDED)

--- a/src/game_stats.py
+++ b/src/game_stats.py
@@ -1,5 +1,4 @@
 import math
-from tkinter import CURRENT
 import numpy as np
 import time
 import threading

--- a/src/game_stats.py
+++ b/src/game_stats.py
@@ -1,4 +1,5 @@
 import math
+from tkinter import CURRENT
 import numpy as np
 import time
 import threading
@@ -114,10 +115,10 @@ class GameStats:
             curr_lvl = get_level(exp[1])['lvl']
             if curr_lvl > 0:
                 self._current_lvl = curr_lvl-1
-        
+
         if self._starting_exp == 0:
             self._starting_exp = exp[0]
-        
+
         if exp[0] > 0:
             self._current_exp = exp[0]
 
@@ -159,26 +160,32 @@ class GameStats:
         avg_length_str = hms(avg_length)
 
         curr_lvl = get_level(self._current_lvl)
-        exp_gained = self._current_exp - curr_lvl['exp']
-        per_to_lvl = exp_gained / curr_lvl["xp_to_next"]
-        gained_exp = self._current_exp - self._starting_exp
-        exp_per_second = gained_exp / good_games_time
-        exp_per_hour = round(exp_per_second * 3600, 1)
-        exp_per_game = round(gained_exp / float(good_games_count), 1)
-        exp_needed = curr_lvl['xp_to_next'] - exp_gained
-        time_to_lvl = exp_needed / exp_per_second
-        games_to_lvl = exp_needed / exp_per_game
 
         msg = f'\nSession length: {elapsed_time_str}'
         msg += f'\nGames: {self._game_counter}'
         msg += f'\nAvg Game Length: {avg_length_str}'
         msg += f'\nCurrent Level: {curr_lvl["lvl"]}'
-        msg += f'\nPercent to Level: {math.ceil(per_to_lvl*100)}%'
-        msg += f'\nXP Gained: {gained_exp:,}'
-        msg += f'\nXP Per Hour: {exp_per_hour:,}'
-        msg += f'\nXP Per Game: {exp_per_game:,}'
-        msg += f'\nTime Needed To Level: {hms(time_to_lvl)}'
-        msg += f'\nGames Needed To Level: {math.ceil(games_to_lvl):,}'
+
+        if curr_lvl["lvl"] < 99:
+            try:
+                exp_gained = self._current_exp - curr_lvl['exp']
+                per_to_lvl = exp_gained / curr_lvl["xp_to_next"]
+                gained_exp = self._current_exp - self._starting_exp
+                exp_per_second = gained_exp / good_games_time
+                exp_per_hour = round(exp_per_second * 3600, 1)
+                exp_per_game = round(gained_exp / float(good_games_count), 1)
+                exp_needed = curr_lvl['xp_to_next'] - exp_gained
+                time_to_lvl = exp_needed / exp_per_second
+                games_to_lvl = exp_needed / exp_per_game
+                msg += f'\nPercent to Level: {math.ceil(per_to_lvl*100)}%'
+                msg += f'\nXP Gained: {gained_exp:,}'
+                msg += f'\nXP Per Hour: {exp_per_hour:,}'
+                msg += f'\nXP Per Game: {exp_per_game:,}'
+                msg += f'\nTime Needed To Level: {hms(time_to_lvl)}'
+                msg += f'\nGames Needed To Level: {math.ceil(games_to_lvl):,}'
+            except:
+                Logger.warning("Failed to log exp")
+                pass
 
         table = BeautifulTable()
         table.set_style(BeautifulTable.STYLE_BOX_ROUNDED)

--- a/src/ui/player_bar.py
+++ b/src/ui/player_bar.py
@@ -33,6 +33,7 @@ def get_experience():
     )[0]
 
     split_text = ocr_result.text.split(' ')
+    split_text = split_text[split_text.index("EXPERIENCE:"):]
     try:
         current_exp = int(split_text[1].replace(',', '').replace('.', ''))
         required_exp = int(split_text[3].replace(',', '').replace('.', ''))

--- a/src/ui/player_bar.py
+++ b/src/ui/player_bar.py
@@ -14,7 +14,7 @@ def get_experience():
     wait(0.05)
     # crop roi
     img = grab()
-    
+
     mouse.move(x_m, y_m-50, randomize = (8,1))
     crop = cut_roi(img, Config().ui_roi["xp_bar_text"])
     ocr_result = Ocr().image_to_text(
@@ -47,14 +47,14 @@ def get_experience():
 if __name__ == "__main__":
     import keyboard
     import os
-    
+
     from screen import start_detecting_window
     start_detecting_window()
-    
+
     keyboard.add_hotkey('f12', lambda: Logger.info('Force Exit (f12)') or os._exit(1))
     print("Go to D2R window and press f11 to start game")
     keyboard.wait("f11")
-    
+
     exp = get_experience()
     Logger.debug(f"EXP curr: {exp[0]}")
     Logger.debug(f"EXP req: {exp[1]}")


### PR DESCRIPTION
Numerous xp ocr issues from ocr finding some random character before the experience word. This will ensure those are dropped from the list and it starts with experience as expected. 