### PR TITLE
Divide by zero fix

### DIFF
--- a/src/game_stats.py
+++ b/src/game_stats.py
@@ -36,7 +36,7 @@ class GameStats:
         self._stats_filename = f'stats_{time.strftime("%Y%m%d_%H%M%S")}.log'
         self._nopickup_active = False
         self._starting_exp = 0
-        self._current_exp = 0
+        self._current_exp = 1
         self._current_lvl = 0
 
     def update_location(self, loc: str):


### PR DESCRIPTION
Setting starting xp to 1 should alleviate any divide by zero issues. It should never get back to 0. 