### PR TITLE
Kill BlizzardError.exe

### DIFF
--- a/src/utils/restart.py
+++ b/src/utils/restart.py
@@ -19,6 +19,7 @@ def process_exists(process_name):
 
 def kill_game():
     while process_exists("D2R.exe"):
+        os.system("taskkill /f /im  BlizzardError.exe")
         os.system("taskkill /f /im  D2R.exe")
         wait(1.0, 1.5)
 


### PR DESCRIPTION
Kill the BlizzardError.exe process before restarting the game.

If the game quits due to an error, a BlizzardError window will appear and it will cause botty to restart the game and then fail to select the game window properly.

This is my first pull requests, so please forgive me if there is something wrong.