### PR TITLE
Bugfix: Item tooltip obscuring close button

### DIFF
--- a/src/inventory/personal.py
+++ b/src/inventory/personal.py
@@ -413,6 +413,8 @@ def inspect_items(inp_img: np.ndarray = None, close_window: bool = True, game_st
             if Config().general["info_screenshots"]:
                 cv2.imwrite("./info_screenshots/failed_item_box_" + time.strftime("%Y%m%d_%H%M%S") + ".png", hovered_item)
     if close_window:
+        if not is_visible(ScreenObjects.RightPanel, img):
+            center_mouse()
         common.close()
     return boxes
 


### PR DESCRIPTION
Depending on the item attribute hover size it can block out the [X] used to exit inventory leading to being stuck in inventory loop every game.

Solved this bug by checking to see if X button is not visible, if it's not visible it'll center the mouse on screen to get rid of item tooltip. Then will close window.