### PR TITLE
Imagine: being able to `from health_manager import mp, hp` in your bot!

### DIFF
--- a/src/health_manager.py
+++ b/src/health_manager.py
@@ -2,9 +2,10 @@ from inventory import belt
 from pather import Location
 import cv2
 import time
+import threading
 import keyboard
 from utils.custom_mouse import mouse
-from utils.misc import wait
+from utils.misc import wait, time_since
 from logger import Logger
 from screen import grab
 import time
@@ -13,140 +14,179 @@ from inventory import common
 from ui import view, meters
 from ui_manager import ScreenObjects, is_visible
 
-pause_state = True
+_pause_state = True
 
 def get_pause_state():
-    global pause_state
-    return pause_state
+	return _pause_state
 
 def set_pause_state(state: bool):
-    global pause_state
-    prev = get_pause_state()
-    if prev != state:
-        debug_str = "pausing" if state else "active"
-        Logger.info(f"Health Manager is now {debug_str}")
-        pause_state = state
+	global _pause_state
+	prev = get_pause_state()
+	if prev != state:
+		debug_str = "pausing" if state else "active"
+		Logger.info(f"Health Manager is now {debug_str}")
+		_pause_state = state
 
-class HealthManager:
-    def __init__(self):
-        self._do_monitor = False
-        self._did_chicken = False
-        self._last_rejuv = time.time()
-        self._last_health = time.time()
-        self._last_mana = time.time()
-        self._last_merc_heal = time.time()
-        self._callback = None
-        self._last_chicken_screenshot = None
-        self._count_panel_detects = 0
+_run = False
+_did_chicken = False
+_last_rejuv = time.time()
+_last_health = time.time()
+_last_mana = time.time()
+_last_merc_heal = time.time()
+_callback = None
+_last_chicken_screenshot = None
+_count_panel_detects = 0
+_hp = None
+_mp = None
+_merc_hp = None
+_thread_id = None
 
-    def stop_monitor(self):
-        self._do_monitor = False
+# Gets the current HP as a percentage
+def hp():
+	return _hp
 
-    def set_callback(self, callback):
-        self._callback = callback
+# Gets the current MP as a percentage
+def mp():
+	return _mp
 
-    def did_chicken(self):
-        return self._did_chicken
+# Gets the current HP of the merc as a percentage
+def merc_hp():
+	return _merc_hp
 
-    def reset_chicken_flag(self):
-        self._did_chicken = False
-        set_pause_state(True)
+def is_in_game():
+	return _hp is not None
 
-    def _do_chicken(self, img):
-        if self._callback is not None:
-            self._callback()
-            self._callback = None
-        if Config().general["info_screenshots"]:
-            self._last_chicken_screenshot = "./info_screenshots/info_debug_chicken_" + time.strftime("%Y%m%d_%H%M%S") + ".png"
-            cv2.imwrite(self._last_chicken_screenshot, img)
-        # clean up key presses that might be pressed in the run_thread
-        keyboard.release(Config().char["stand_still"])
-        wait(0.02, 0.05)
-        keyboard.release(Config().char["show_items"])
-        wait(0.02, 0.05)
-        mouse.release(button="left")
-        wait(0.02, 0.05)
-        mouse.release(button="right")
-        time.sleep(0.01)
-        view.save_and_exit()
-        self._did_chicken = True
-        set_pause_state(True)
+def is_merc_alive():
+	return _merc_hp is not None
 
-    def start_monitor(self):
-        Logger.info("Start health monitoring")
-        self._do_monitor = True
-        self._did_chicken = False
-        start = time.time()
-        while self._do_monitor:
-            time.sleep(0.1)
-            # Wait until the flag is reset by main.py
-            if self._did_chicken or get_pause_state(): continue
-            img = grab()
-            if is_visible(ScreenObjects.InGame, img):
-                health_percentage = meters.get_health(img)
-                mana_percentage = meters.get_mana(img)
-                # check rejuv
-                success_drink_rejuv = False
-                last_drink = time.time() - self._last_rejuv
-                if (health_percentage < Config().char["take_rejuv_potion_health"] and last_drink > 1) or \
-                   (mana_percentage < Config().char["take_rejuv_potion_mana"] and last_drink > 2):
-                    success_drink_rejuv = belt.drink_potion("rejuv", stats=[health_percentage, mana_percentage])
-                    self._last_rejuv = time.time()
-                # in case no rejuv was used, check for chicken, health pot and mana pot usage
-                if not success_drink_rejuv:
-                    # check health
-                    last_drink = time.time() - self._last_health
-                    if health_percentage < Config().char["take_health_potion"] and last_drink > 3.5:
-                        belt.drink_potion("health", stats=[health_percentage, mana_percentage])
-                        self._last_health = time.time()
-                    # give the chicken a 6 sec delay to give time for a healing pot and avoid endless loop of chicken
-                    elif health_percentage < Config().char["chicken"] and (time.time() - start) > 6:
-                        Logger.warning(f"Trying to chicken, player HP {(health_percentage*100):.1f}%!")
-                        self._do_chicken(img)
-                    # check mana
-                    last_drink = time.time() - self._last_mana
-                    if mana_percentage < Config().char["take_mana_potion"] and last_drink > 4:
-                        belt.drink_potion("mana", stats=[health_percentage, mana_percentage])
-                        self._last_mana = time.time()
-                # check merc
-                if is_visible(ScreenObjects.MercIcon, img):
-                    merc_health_percentage = meters.get_merc_health(img)
-                    last_drink = time.time() - self._last_merc_heal
-                    if merc_health_percentage < Config().char["merc_chicken"]:
-                        Logger.warning(f"Trying to chicken, merc HP {(merc_health_percentage*100):.1f}%!")
-                        self._do_chicken(img)
-                    if merc_health_percentage < Config().char["heal_rejuv_merc"] and last_drink > 4.0:
-                        belt.drink_potion("rejuv", merc=True, stats=[merc_health_percentage])
-                        self._last_merc_heal = time.time()
-                    elif merc_health_percentage < Config().char["heal_merc"] and last_drink > 7.0:
-                        belt.drink_potion("health", merc=True, stats=[merc_health_percentage])
-                        self._last_merc_heal = time.time()
-                if is_visible(ScreenObjects.LeftPanel, img) or is_visible(ScreenObjects.RightPanel, img):
-                    Logger.warning(f"Found an open inventory / quest / skill / stats page. Close it.")
-                    self._count_panel_detects += 1
-                    if self._count_panel_detects >= 2:
-                        self._count_panel_detects = 0
-                        Logger.warning(f"Found an open inventory / quest / skill / stats page again. Chicken to dismiss.")
-                        self._do_chicken(img)
-                    common.close()
-        Logger.debug("Stop health monitoring")
+# Updates the current HP, MP, and merc HP from a screen grab image
+def update_values(img):
+	global _hp, _mp, _merc_hp
+
+	if is_visible(ScreenObjects.InGame, img):
+		_hp = meters.get_health(img)
+		_mp = meters.get_mana(img)
+
+		if is_visible(ScreenObjects.MercIcon, img):
+			_merc_hp = meters.get_merc_health(img)
+		else:
+			_merc_hp = None
+
+def stop_monitor():
+	_run = False
+
+def set_callback(callback):
+	_callback = callback
+
+def did_chicken():
+	return _did_chicken
+
+def reset_chicken_flag():
+	_did_chicken = False
+	set_pause_state(True)
+
+def _do_chicken(img):
+	global _did_chicken, _callback
+
+	if _callback is not None:
+		_callback()
+		_callback = None
+	if Config().general["info_screenshots"]:
+		_last_chicken_screenshot = "./info_screenshots/info_debug_chicken_" + time.strftime("%Y%m%d_%H%M%S") + ".png"
+		cv2.imwrite(_last_chicken_screenshot, img)
+	# clean up key presses that might be pressed in the run_thread
+	keyboard.release(Config().char["stand_still"])
+	wait(0.02, 0.05)
+	keyboard.release(Config().char["show_items"])
+	wait(0.02, 0.05)
+	mouse.release(button="left")
+	wait(0.02, 0.05)
+	mouse.release(button="right")
+	time.sleep(0.01)
+	view.save_and_exit()
+	_did_chicken = True
+	set_pause_state(True)
+
+def start_health_manager():
+	# Ensure this method runs in one thread only
+	global _thread_id, _run, _did_chicken, _last_rejuv, _last_mana, _last_health, _last_merc_heal, _count_panel_detects
+
+	if _thread_id is not None and _thread_id != threading.get_ident():
+		Logger.info(f"Health monitor thread already running: {_thread_id}. Returning")
+		return
+	_thread_id = threading.get_ident()
+
+	Logger.info("Start health monitoring")
+
+	_run = True
+	_did_chicken = False
+	start = time.time()
+	while _run:
+		time.sleep(0.1)
+		# Wait until the flag is reset by main.py
+		if _did_chicken or get_pause_state(): continue
+		img = grab()
+		update_values(img)
+
+		if is_in_game():
+			# check rejuv
+			success_drink_rejuv = False
+
+			if (hp() < Config().char["take_rejuv_potion_health"] and time_since(_last_rejuv) > 1) or \
+			   (mp() < Config().char["take_rejuv_potion_mana"] and time_since(_last_rejuv) > 2):
+				success_drink_rejuv = belt.drink_potion("rejuv", stats=[hp(), mp()])
+				_last_rejuv = time.time()
+			# in case no rejuv was used, check for chicken, health pot and mana pot usage
+			if not success_drink_rejuv:
+				# check health
+				last_drink = time.time() - _last_health
+				if hp() < Config().char["take_health_potion"] and time_since(_last_health) > 3.5:
+					belt.drink_potion("health", stats=[hp(), mp()])
+					_last_health = time.time()
+				# give the chicken a 6 sec delay to give time for a healing pot and avoid endless loop of chicken
+				elif hp() < Config().char["chicken"] and (time.time() - start) > 6:
+					Logger.warning(f"Trying to chicken, player HP {(hp()*100):.1f}%!")
+					_do_chicken(img)
+				# check mana
+				last_drink = time.time() - _last_mana
+				if mp() < Config().char["take_mana_potion"] and last_drink > 4:
+					belt.drink_potion("mana", stats=[hp(), mp()])
+					_last_mana = time.time()
+			# check merc
+			if is_merc_alive():
+				last_drink = time.time() - _last_merc_heal
+				if merc_hp() < Config().char["merc_chicken"]:
+					Logger.warning(f"Trying to chicken, merc HP {(merc_hp()*100):.1f}%!")
+					_do_chicken(img)
+				if merc_hp() < Config().char["heal_rejuv_merc"] and last_drink > 4.0:
+					belt.drink_potion("rejuv", merc=True, stats=[merc_hp()])
+					_last_merc_heal = time.time()
+				elif merc_hp() < Config().char["heal_merc"] and last_drink > 7.0:
+					belt.drink_potion("health", merc=True, stats=[merc_hp()])
+					_last_merc_heal = time.time()
+			if is_visible(ScreenObjects.LeftPanel, img) or is_visible(ScreenObjects.RightPanel, img):
+				Logger.warning(f"Found an open inventory / quest / skill / stats page. Close it.")
+				_count_panel_detects += 1
+				if _count_panel_detects >= 2:
+					_count_panel_detects = 0
+					Logger.warning(f"Found an open inventory / quest / skill / stats page again. Chicken to dismiss.")
+					_do_chicken(img)
+				common.close()
+	Logger.debug("Stop health monitoring")
 
 
 # Testing: Start dying or losing mana and see if it works
 if __name__ == "__main__":
-    import threading
-    import keyboard
-    import os
-    from health_manager import set_pause_state
-    keyboard.add_hotkey('f12', lambda: Logger.info('Exit Health Manager') or os._exit(1))
-    manager = HealthManager()
-    set_pause_state(True)
-    Logger.info("Press f12 to exit health manager")
-    health_monitor_thread = threading.Thread(target=manager.start_monitor)
-    health_monitor_thread.start()
-    while 1:
-        if manager.did_chicken():
-            manager.stop_monitor()
-            health_monitor_thread.join()
-            break
-        wait(0.5)
+	import keyboard
+	import os
+	keyboard.add_hotkey('f12', lambda: Logger.info('Exit Health Manager') or os._exit(1))
+	set_pause_state(True)
+	Logger.info("Press f12 to exit health manager")
+	health_monitor_thread = threading.Thread(target=start_health_manager)
+	health_monitor_thread.start()
+	while 1:
+		if did_chicken():
+			stop_monitor()
+			health_monitor_thread.join()
+			break
+		wait(0.5)

--- a/src/utils/misc.py
+++ b/src/utils/misc.py
@@ -79,6 +79,9 @@ def restore_d2r_window_visibility():
     else:
         print('OS not supported, unable to set D2R always on top')
 
+def time_since(t: float):
+    return time.time() - t
+
 def wait(min_seconds, max_seconds = None):
     if max_seconds is None:
         max_seconds = min_seconds


### PR DESCRIPTION
This PR makes the health_manager effectively into a singleton, which maintains a single global state, rather than keeping it as a class that can be instantiated multiple times.  Unless there is a use case for having multiple health managers running simultaneously in the same process, there's no reason to allow it to instantiate multiple versions of its state.  There are multiple patterns in python to do this, I could have decided on an actual singleton class decorator implementation, or used the "borg" pattern to set the state of all health_managers the same, but this seemed by far the most idiomatic and least verbose.  I've attempted to somewhat limit the changes here, though I've got tabs configured for this project in my editor from editing the ranged bot and other files - so... LMK if you want those back as spaces

The reason I wanted this in the first place was because I'd love to be able to validate that a spell was cast from within my bot by ensuring the mana went down.  There currently seems to be no way to cleanly check the HP/MP from within a bot.  This will allow any bot to simply `from health_manager import hp, mp` to call `hp()` and `mp()` from within their bot class.  Though... y'all might be thinking about my logic for changing this from being a class (no two instantiated in a single process), and realizing the same holds true for a bot, I don't see any reason to prioritize refactoring that, and inheritance can be a useful tool for bot creation.

I've only copied in files that are working for me, still need to test this more thoroughly.