### PR TITLE
Bugfix: False empty stash tabs due to item tooltip

### DIFF
--- a/src/inventory/common.py
+++ b/src/inventory/common.py
@@ -10,24 +10,9 @@ from utils.misc import wait, trim_black, color_filter, cut_roi
 from inventory import consumables
 from ui import view
 from screen import convert_screen_to_monitor, grab
-from dataclasses import dataclass
 from logger import Logger
 from ocr import Ocr
 from template_finder import TemplateMatch
-
-@dataclass
-class BoxInfo:
-    img: np.ndarray = None
-    pos: tuple = None
-    column: int = None
-    row: int = None
-    need_id: bool = False
-    sell: bool = False
-    keep: bool = False
-    def __getitem__(self, key):
-        return super().__getattribute__(key)
-    def __setitem__(self, key, value):
-        setattr(self, key, value)
 
 def get_slot_pos_and_img(img: np.ndarray, column: int, row: int) -> tuple[tuple[int, int],  np.ndarray]:
     """


### PR DESCRIPTION
Fixes a bug introduced in 7.2 after attempting to fix another bug. 

The current bug manifests with users having their botty quit after attempting to stash/sell/drop an item whose tooltip was too large causing calc_roi() to fail. Calc_roi will still fail with this bugfix, but now anytime an item is to be transferred it will first make sure that inventory slot is not empty. If it is empty, that item will be skipped.

Here is an example of Herald of Zakarum stashing and not causing game to quit when it previously did.

![image](https://user-images.githubusercontent.com/9866239/163533436-ba10be14-94e1-4cb5-b1cf-60451d911525.png)

While fixing calc_roi would be nice, this should hopefully no longer be a necessary function with implementation of HoveredItem from d2r_image library by @Ezro, hoping to have 0.8.0 out soon.