### PR TITLE
Bugfix: Cain loop, etc. with return_to_play() function

### DIFF
--- a/src/ui/view.py
+++ b/src/ui/view.py
@@ -81,7 +81,7 @@ def return_to_play() -> bool:
     substrings = ["NPC", "Panel", "SaveAndExit"]
     img=grab()
     start=time.time()
-    while (elapsed := (time.time() - start) < 5):
+    while (elapsed := (time.time() - start) < 8):
         need_escape = False
         match = detect_screen_object(ScreenObjects.InGame, img)
         if match.valid and "DARK" in match.name:
@@ -92,7 +92,7 @@ def return_to_play() -> bool:
                     break
         if need_escape:
             keyboard.send("esc")
-            wait(1)
+            wait(1.7)
             img=grab()
         else:
             break
@@ -113,9 +113,4 @@ if __name__ == "__main__":
     from config import Config
     from template_finder import TemplateFinder
 
-    while True:
-        img = grab()
-        if (result := TemplateFinder().search(["YOU_HAVE_DIED", "NOT_ENOUGH_GOLD"], img, color_match=Config().colors["red"], use_grayscale=True, best_match=True)).valid:
-            print(f"match: {result.score}")
-        else:
-            print("no match")
+    return_to_play()


### PR DESCRIPTION
Discord Bug Report 3:

> Some users experience a loop of save/exit after interacting with cain. The issue seems most common with latency issues or on VM's. The causative function is return_to_play() in view.py. A fix will require adjusting the logic of that function. Current workaround is to use an ID tome in your inventory.

Here I've increased the time limit on return_to_play() from 5 seconds to 8 seconds and then increased the wait time before checking templates again.

I've tested on my character (I'm US East) on Asia server. No loop with Cain. Not sure if this will solve for all users or not. Ideal solution will probably require better logic than current implementation.