### PR TITLE
Disable mods for planned upcoming stable release

### DIFF
--- a/config/params.ini
+++ b/config/params.ini
@@ -279,4 +279,4 @@ hwnd_window_process=D2R\.exe
 ;If you want to control Hyper-V window from host use 0,51 here
 window_client_area_offset=0,0
 ocr_during_pickit=0
-launch_options=-mod botty -txt
+launch_options=


### PR DESCRIPTION
Deletes default `launch_options` param config so botty won't attempt to use mod files for planned upcoming stable release. Will set default `launch_options` again once mods are needed for OCR pickit release.