### PR TITLE
Bone necro

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ order=run_pindle, run_eldritch
 | amp_dmg        | Required Hotkey for Amplify Damage                                                  |
 | corpse_explosion | Required Hotkey Corpse Explosion                                                  |
 | raise_revive   | Required Hotkey revive                                                              |
+| damage_scaling   | Adjusts time spent casting attack skills. Ex: 2 will cast twice as long           |
 | clear_pindle_packs | clears mobs before pindle                                                       |
 
 | [dclone]             | Descriptions                                                          |

--- a/config/params.ini
+++ b/config/params.ini
@@ -222,6 +222,16 @@ corpse_explosion=
 clear_pindle_pack=
 heart_of_wolverine=
 
+[bone_necro]
+teleport=
+teeth=
+bone_armor=
+clay_golem=
+bone_wall=
+bone_spear=
+bone_spirit=
+damage_scaling=1
+
 ; ===========================
 ; ==== Builds: Basic ====
 ; ===========================

--- a/config/params.ini
+++ b/config/params.ini
@@ -230,6 +230,8 @@ clay_golem=
 bone_wall=
 bone_spear=
 bone_spirit=
+; Damage scaling. One setting to adjust kill speed to account for better/worse gear. 
+; ex: 2 will cast all attack skills twice a long, .5 half as long. Currently only used by bone necro
 damage_scaling=1
 
 ; ===========================

--- a/src/bot.py
+++ b/src/bot.py
@@ -28,6 +28,7 @@ from char.hammerdin import Hammerdin
 from char.barbarian import Barbarian
 from char.necro import Necro
 from char.poison_necro import Poison_Necro
+from char.bone_necro import Bone_Necro
 from char.basic import Basic
 from char.basic_ranged import Basic_Ranged
 from ui_manager import wait_until_hidden, wait_until_visible, ScreenObjects, is_visible
@@ -66,6 +67,8 @@ class Bot:
             self._char: IChar = Barbarian(Config().barbarian, self._pather)
         elif Config().char["type"] == "poison_necro":
             self._char: IChar = Poison_Necro(Config().poison_necro, self._pather)
+        elif Config().char["type"] == "bone_necro":
+            self._char: IChar = Bone_Necro(Config().bone_necro, self._pather)
         elif Config().char["type"] == "necro":
             self._char: IChar = Necro(Config().necro, self._pather)
         elif Config().char["type"] == "basic":

--- a/src/char/bone_necro.py
+++ b/src/char/bone_necro.py
@@ -1,0 +1,223 @@
+import keyboard
+from utils.custom_mouse import mouse
+from char import IChar
+from template_finder import TemplateFinder
+from pather import Pather
+from logger import Logger
+from screen import grab, convert_abs_to_monitor, convert_screen_to_abs
+from config import Config
+from utils.misc import wait, rotate_vec, unit_vector
+import random
+from typing import Tuple
+from pather import Location, Pather
+import screen as screen
+import numpy as np
+import time
+import os
+from ui_manager import ScreenObjects
+
+class Bone_Necro(IChar):
+    def __init__(self, skill_hotkeys: dict, pather: Pather):
+        os.system('color')
+        Logger.info("\033[94m<<Setting up Necro>>\033[0m")
+        super().__init__(skill_hotkeys)
+        self._pather = pather
+    
+    def bone_wall(self, cast_pos_abs: Tuple[float, float], spray: int):
+        if not self._skill_hotkeys["bone_wall"]:
+            raise ValueError("You did not set bone_wall hotkey!")
+        keyboard.send(Config().char["stand_still"], do_release=False)
+        keyboard.send(self._skill_hotkeys["bone_wall"])
+        wait(0.02, 0.08)
+        x = cast_pos_abs[0] + (random.random() * 2*spray - spray)
+        y = cast_pos_abs[1] + (random.random() * 2*spray - spray)
+        cast_pos_monitor = convert_abs_to_monitor((x, y))
+        mouse.move(*cast_pos_monitor)
+        mouse.press(button="right")
+        wait(self._cast_duration+.04, self._cast_duration+.08)
+        mouse.release(button="right")
+        keyboard.send(Config().char["stand_still"], do_press=False)    
+
+    def pre_buff(self):
+        self.bone_armor()
+        #only CTA if pre trav
+        if Config().char["cta_available"]:
+            self._pre_buff_cta()
+        Logger.info("prebuff/cta")
+
+    def _clay_golem(self):
+        Logger.info('\033[94m'+"cast ~> clay golem"+'\033[0m')
+        keyboard.send(self._skill_hotkeys["clay_golem"])
+        wait(0.05, 0.2)
+        mouse.click(button="right")
+        wait(self._cast_duration)
+
+    def bone_armor(self):
+        if self._skill_hotkeys["bone_armor"]:
+            keyboard.send(self._skill_hotkeys["bone_armor"])
+            wait(0.04, 0.1)
+            mouse.click(button="right")
+            wait(self._cast_duration)
+        if self._skill_hotkeys["clay_golem"]:
+            keyboard.send(self._skill_hotkeys["clay_golem"])
+            wait(0.04, 0.1)
+            mouse.click(button="right")
+            wait(self._cast_duration)
+
+    def _bone_armor(self):
+        if self._skill_hotkeys["bone_armor"]:
+            keyboard.send(self._skill_hotkeys["bone_armor"])
+            wait(0.04, 0.1)
+            mouse.click(button="right")
+            wait(self._cast_duration)
+
+    def _corpse_explosion(self, cast_pos_abs: Tuple[float, float], spray: int = 10,cast_count: int = 8):
+        keyboard.send(Config().char["stand_still"], do_release=False)
+        Logger.info('\033[93m'+"corpse explosion~> random cast"+'\033[0m')
+        for _ in range(cast_count):
+            if self._skill_hotkeys["corpse_explosion"]:
+                keyboard.send(self._skill_hotkeys["corpse_explosion"])
+                x = cast_pos_abs[0] + (random.random() * 2*spray - spray)
+                y = cast_pos_abs[1] + (random.random() * 2*spray - spray)
+                cast_pos_monitor = convert_abs_to_monitor((x, y))
+                mouse.move(*cast_pos_monitor)
+                mouse.press(button="right")
+                wait(0.075, 0.1)
+                mouse.release(button="right")
+        keyboard.send(Config().char["stand_still"], do_press=False)
+
+    def move_to(self, x, y):
+        pos_m = convert_abs_to_monitor((x, y))
+        self.pre_move()
+        self.move(pos_m, force_move=True)
+
+    def _lerp(self,a: float,b: float, f:float):
+        return a + f * (b - a)
+
+    def _cast_circle(self, cast_dir: Tuple[float,float],cast_start_angle: float=0.0, cast_end_angle: float=90.0,cast_div: int = 10,cast_spell: str='raise_skeleton',delay: float=1.0, radius=120, hold_duration: float = 3, hold=True):
+        Logger.info('\033[93m'+"circle cast ~>"+cast_spell+'\033[0m')
+        keyboard.send(Config().char["stand_still"], do_release=False)
+        keyboard.send(self._skill_hotkeys[cast_spell])
+        if hold:
+            mouse.press(button="right")
+
+        for i in range(cast_div):
+            angle = self._lerp(cast_start_angle,cast_end_angle,float(i)/cast_div)
+            target = unit_vector(rotate_vec(cast_dir, angle))
+            #Logger.info("current angle ~> "+str(angle))
+            circle_pos_screen = self._pather._adjust_abs_range_to_screen(target*radius)
+            circle_pos_monitor = convert_abs_to_monitor(circle_pos_screen)
+            start = time.time()
+            mouse.move(*circle_pos_monitor,delay_factor=[0.95*delay, 1.05*delay])
+            duration = time.time() - start
+
+            if not hold:
+                mouse.press(button="right")
+                wait(.04, .08)
+                mouse.release(button="right")
+                wait(self._cast_duration)
+            else:
+                #adjust the speed so we finish in approximately the time requested
+                expected = (hold_duration/cast_div)
+                delay = delay*(expected/duration)
+                #Logger.info("circle move")
+        if hold:
+            mouse.release(button="right")
+        keyboard.send(Config().char["stand_still"], do_press=False)
+
+
+    def kill_pindle(self) -> bool:
+        for pos in [[200,-100], [-150,100] ]:
+            self.bone_wall(pos, spray=10)
+        self.cast_in_arc(ability='bone_spear', cast_pos_abs=[110,-50], spread_deg=15, time_in_s=5)
+        self._corpse_explosion([165,-75], spray=100, cast_count=5)
+        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[110,-50], spread_deg=15, time_in_s=2.5)
+        self._pather.traverse_nodes_fixed("pindle_end", self)
+        return True
+
+    def kill_eldritch(self) -> bool:
+        #build an arc of bone walls
+        for pos in [[50,-200], [-200,-175], [-350,50]]:
+            self.bone_wall(pos, spray=10)
+        self.cast_in_arc(ability='teeth', cast_pos_abs=[-20,-150], spread_deg=15, time_in_s=3)
+        self.cast_in_arc(ability='bone_spear', cast_pos_abs=[-20,-150], spread_deg=15, time_in_s=2)
+        self._corpse_explosion([-20,-240], spray=100, cast_count=5)
+        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[0,-80], spread_deg=60, time_in_s=2.5)
+        self._pather.traverse_nodes((Location.A5_ELDRITCH_SAFE_DIST, Location.A5_ELDRITCH_END), self, timeout=0.6, force_tp=True)
+        self.bone_armor()
+        return True
+
+
+    def kill_shenk(self) -> bool:
+        self._cast_circle(cast_dir=[1,1],cast_start_angle=0,cast_end_angle=360,cast_div=5,cast_spell='bone_wall',delay=.8,radius=100, hold=False)
+        self.cast_in_arc(ability='teeth', cast_pos_abs=[160,75], spread_deg=360, time_in_s=6)
+        self.cast_in_arc(ability='teeth', cast_pos_abs=[160,75], spread_deg=30, time_in_s=2)
+        self._corpse_explosion([0,0], spray=200, cast_count=4)
+        self.cast_in_arc(ability='bone_spear', cast_pos_abs=[160,75], spread_deg=30, time_in_s=3)
+        self._corpse_explosion([240,112], spray=200, cast_count=8)
+        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[80,37], spread_deg=60, time_in_s=3)
+        self._pather.traverse_nodes((Location.A5_SHENK_SAFE_DIST, Location.A5_SHENK_END), self, timeout=1.0)
+        return True
+
+
+    def kill_council(self) -> bool:
+        #move down adjacent to the right moat
+        self.move_to(-150,150)
+        self.move_to(-150,150)
+ 
+        #moat on right side, encircle with bone walls on the other 3 sides
+        for pos in [[100,-100], [-125,-25], [-50,100]]:
+            self.bone_wall(pos, spray=10)
+        self.cast_in_arc(ability='teeth', cast_pos_abs=[25,-100], spread_deg=270, time_in_s=5)
+        self.cast_in_arc(ability='bone_spear', cast_pos_abs=[25,-100], spread_deg=120, time_in_s=8)
+        self._corpse_explosion([25,-100], spray=200, cast_count=8)
+        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[10,-50], spread_deg=180, time_in_s=6)
+        self._corpse_explosion([25,-100], spray=200, cast_count=8)
+        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[10,-50], spread_deg=360, time_in_s=5)
+        
+        return True
+
+
+    def kill_nihlathak(self, end_nodes: list[int]) -> bool:
+        # Find nilhlatak position
+        nihlathak_pos_abs = self._pather.find_abs_node_pos(end_nodes[-1], grab())
+        if nihlathak_pos_abs is None:
+            return False
+            
+        cast_pos_abs = np.array(nihlathak_pos_abs)*.2
+        self._cast_circle(cast_dir=[1,1],cast_start_angle=0,cast_end_angle=360,cast_div=5,cast_spell='bone_wall',delay=.8,radius=100, hold=False)
+        self._bone_armor()
+        self.cast_in_arc(ability='teeth', cast_pos_abs=cast_pos_abs, spread_deg=150, time_in_s=5)
+        self._bone_armor()
+        self._corpse_explosion(cast_pos_abs, spray=200, cast_count=8)
+        self.cast_in_arc(ability='bone_spear', cast_pos_abs=cast_pos_abs, spread_deg=10, time_in_s=5)
+        self._bone_armor()
+
+        self._corpse_explosion(np.array(nihlathak_pos_abs)*.75, spray=200, cast_count=10)
+        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=cast_pos_abs, spread_deg=30, time_in_s=2.5)
+
+        # Move to items
+        wait(self._cast_duration, self._cast_duration + 0.2)
+        self._pather.traverse_nodes(end_nodes, self, timeout=0.8)
+        return True
+
+    def kill_summoner(self) -> bool:
+        # Attack
+        for i in range(2):
+            self.cast_in_arc(ability='teeth', cast_pos_abs=[30,30], spread_deg=360, time_in_s=1.5)
+        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[30,30], spread_deg=360, time_in_s=1.5)
+        self._corpse_explosion([0,0], spray=200, cast_count=8)
+        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[30,30], spread_deg=360, time_in_s=1.5)
+            
+        return True               
+
+
+if __name__ == "__main__":
+    import os
+    import keyboard
+    keyboard.add_hotkey('f12', lambda: Logger.info('Force Exit (f12)') or os._exit(1))
+    keyboard.wait("f11")
+    from config import Config
+    from char import Necro
+    pather = Pather()
+    char = Necro(Config().necro, Config().char, pather)

--- a/src/char/bone_necro.py
+++ b/src/char/bone_necro.py
@@ -18,11 +18,16 @@ from ui_manager import ScreenObjects
 
 class Bone_Necro(IChar):
     def __init__(self, skill_hotkeys: dict, pather: Pather):
-        os.system('color')
-        Logger.info("\033[94m<<Setting up Necro>>\033[0m")
+        Logger.info("Setting up Bone Necro")
         super().__init__(skill_hotkeys)
         self._pather = pather
-        self.damage_scaling = float(Config().bone_necro.get("damage_scaling", 1.0))
+        if "damage_scaling" in Config().bone_necro:
+            self.damage_scaling = float(Config().bone_necro["damage_scaling"])
+            
+    def move_to(self, x, y):
+        pos_m = convert_abs_to_monitor((x, y))
+        self.pre_move()
+        self.move(pos_m, force_move=True)
     
     def bone_wall(self, cast_pos_abs: Tuple[float, float], spray: int):
         if not self._skill_hotkeys["bone_wall"]:
@@ -47,7 +52,7 @@ class Bone_Necro(IChar):
         Logger.info("prebuff/cta")
 
     def _clay_golem(self):
-        Logger.info('\033[94m'+"cast ~> clay golem"+'\033[0m')
+        Logger.debug('Casting clay golem')
         keyboard.send(self._skill_hotkeys["clay_golem"])
         wait(0.05, 0.2)
         mouse.click(button="right")
@@ -74,7 +79,7 @@ class Bone_Necro(IChar):
 
     def _corpse_explosion(self, cast_pos_abs: Tuple[float, float], spray: int = 10,cast_count: int = 8):
         keyboard.send(Config().char["stand_still"], do_release=False)
-        Logger.info('\033[93m'+"corpse explosion~> random cast"+'\033[0m')
+        Logger.debug(f'casting corpse explosion {cast_count} times with spray = {spray}')
         for _ in range(cast_count):
             if self._skill_hotkeys["corpse_explosion"]:
                 keyboard.send(self._skill_hotkeys["corpse_explosion"])
@@ -87,16 +92,16 @@ class Bone_Necro(IChar):
                 mouse.release(button="right")
         keyboard.send(Config().char["stand_still"], do_press=False)
 
-    def move_to(self, x, y):
-        pos_m = convert_abs_to_monitor((x, y))
-        self.pre_move()
-        self.move(pos_m, force_move=True)
 
     def _lerp(self,a: float,b: float, f:float):
         return a + f * (b - a)
 
     def _cast_circle(self, cast_dir: Tuple[float,float],cast_start_angle: float=0.0, cast_end_angle: float=90.0,cast_div: int = 10,cast_spell: str='raise_skeleton',delay: float=1.0, radius=120, hold_duration: float = 3, hold=True):
-        Logger.info('\033[93m'+"circle cast ~>"+cast_spell+'\033[0m')
+        if hold:
+            Logger.info(f'Circle cast {cast_spell} from {cast_start_angle}º to {cast_end_angle}º over {hold_duration}s')
+        else:
+            Logger.info(f'Circle cast {cast_spell} from {cast_start_angle}º to {cast_end_angle}º over {cast_div} casts')
+        
         keyboard.send(Config().char["stand_still"], do_release=False)
         keyboard.send(self._skill_hotkeys[cast_spell])
         if hold:
@@ -105,7 +110,7 @@ class Bone_Necro(IChar):
         for i in range(cast_div):
             angle = self._lerp(cast_start_angle,cast_end_angle,float(i)/cast_div)
             target = unit_vector(rotate_vec(cast_dir, angle))
-            #Logger.info("current angle ~> "+str(angle))
+            Logger.debug(f"Circle cast - current angle: {angle}º")
             circle_pos_screen = self._pather._adjust_abs_range_to_screen(target*radius)
             circle_pos_monitor = convert_abs_to_monitor(circle_pos_screen)
             start = time.time()
@@ -121,7 +126,6 @@ class Bone_Necro(IChar):
                 #adjust the speed so we finish in approximately the time requested
                 expected = (hold_duration/cast_div)
                 delay = delay*(expected/duration)
-                #Logger.info("circle move")
         if hold:
             mouse.release(button="right")
         keyboard.send(Config().char["stand_still"], do_press=False)
@@ -130,9 +134,9 @@ class Bone_Necro(IChar):
     def kill_pindle(self) -> bool:
         for pos in [[200,-100], [-150,100] ]:
             self.bone_wall(pos, spray=10)
-        self.cast_in_arc(ability='bone_spear', cast_pos_abs=[110,-50], spread_deg=15, time_in_s=self.damage_scaling*5)
+        self.cast_in_arc(ability='bone_spear', cast_pos_abs=[110,-50], spread_deg=15, time_in_s=5)
         self._corpse_explosion([165,-75], spray=100, cast_count=5)
-        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[110,-50], spread_deg=15, time_in_s=self.damage_scaling*2.5)
+        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[110,-50], spread_deg=15, time_in_s=2.5)
         self._pather.traverse_nodes_fixed("pindle_end", self)
         return True
 
@@ -140,10 +144,10 @@ class Bone_Necro(IChar):
         #build an arc of bone walls
         for pos in [[50,-200], [-200,-175], [-350,50]]:
             self.bone_wall(pos, spray=10)
-        self.cast_in_arc(ability='teeth', cast_pos_abs=[-20,-150], spread_deg=15, time_in_s=self.damage_scaling*3)
-        self.cast_in_arc(ability='bone_spear', cast_pos_abs=[-20,-150], spread_deg=15, time_in_s=self.damage_scaling*2)
+        self.cast_in_arc(ability='teeth', cast_pos_abs=[-20,-150], spread_deg=15, time_in_s=3)
+        self.cast_in_arc(ability='bone_spear', cast_pos_abs=[-20,-150], spread_deg=15, time_in_s=2)
         self._corpse_explosion([-20,-240], spray=100, cast_count=5)
-        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[0,-80], spread_deg=60, time_in_s=self.damage_scaling*2.5)
+        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[0,-80], spread_deg=60, time_in_s=2.5)
         self._pather.traverse_nodes((Location.A5_ELDRITCH_SAFE_DIST, Location.A5_ELDRITCH_END), self, timeout=0.6, force_tp=True)
         self.bone_armor()
         return True
@@ -151,12 +155,12 @@ class Bone_Necro(IChar):
 
     def kill_shenk(self) -> bool:
         self._cast_circle(cast_dir=[1,1],cast_start_angle=0,cast_end_angle=360,cast_div=5,cast_spell='bone_wall',delay=.8,radius=100, hold=False)
-        self.cast_in_arc(ability='teeth', cast_pos_abs=[160,75], spread_deg=360, time_in_s=self.damage_scaling*6)
-        self.cast_in_arc(ability='teeth', cast_pos_abs=[160,75], spread_deg=30, time_in_s=self.damage_scaling*2)
+        self.cast_in_arc(ability='teeth', cast_pos_abs=[160,75], spread_deg=360, time_in_s=6)
+        self.cast_in_arc(ability='teeth', cast_pos_abs=[160,75], spread_deg=30, time_in_s=2)
         self._corpse_explosion([0,0], spray=200, cast_count=4)
-        self.cast_in_arc(ability='bone_spear', cast_pos_abs=[160,75], spread_deg=30, time_in_s=self.damage_scaling*3)
+        self.cast_in_arc(ability='bone_spear', cast_pos_abs=[160,75], spread_deg=30, time_in_s=3)
         self._corpse_explosion([240,112], spray=200, cast_count=8)
-        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[80,37], spread_deg=60, time_in_s=self.damage_scaling*3)
+        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[80,37], spread_deg=60, time_in_s=3)
         self._pather.traverse_nodes((Location.A5_SHENK_SAFE_DIST, Location.A5_SHENK_END), self, timeout=1.0)
         return True
 
@@ -169,13 +173,13 @@ class Bone_Necro(IChar):
         #moat on right side, encircle with bone walls on the other 3 sides
         for pos in [[100,-100], [-125,-25], [-50,100]]:
             self.bone_wall(pos, spray=10)
-        self.cast_in_arc(ability='teeth', cast_pos_abs=[40,-100], spread_deg=180, time_in_s=self.damage_scaling*5)
-        self.cast_in_arc(ability='bone_spear', cast_pos_abs=[40,-100], spread_deg=120, time_in_s=self.damage_scaling*8)
+        self.cast_in_arc(ability='teeth', cast_pos_abs=[40,-100], spread_deg=180, time_in_s=5)
+        self.cast_in_arc(ability='bone_spear', cast_pos_abs=[40,-100], spread_deg=120, time_in_s=8)
         
         self._corpse_explosion([40,-100], spray=200, cast_count=8)
-        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[20,-50], spread_deg=180, time_in_s=self.damage_scaling*5)
+        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[20,-50], spread_deg=180, time_in_s=5)
         self._corpse_explosion([40,-100], spray=200, cast_count=8)
-        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[20,-50], spread_deg=360, time_in_s=self.damage_scaling*4)
+        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[20,-50], spread_deg=360, time_in_s=4)
         
         return True
 
@@ -189,14 +193,14 @@ class Bone_Necro(IChar):
         cast_pos_abs = np.array(nihlathak_pos_abs)*.2
         self._cast_circle(cast_dir=[1,1],cast_start_angle=0,cast_end_angle=360,cast_div=5,cast_spell='bone_wall',delay=.8,radius=100, hold=False)
         self._bone_armor()
-        self.cast_in_arc(ability='teeth', cast_pos_abs=cast_pos_abs, spread_deg=150, time_in_s=self.damage_scaling*5)
+        self.cast_in_arc(ability='teeth', cast_pos_abs=cast_pos_abs, spread_deg=150, time_in_s=5)
         self._bone_armor()
         self._corpse_explosion(cast_pos_abs, spray=200, cast_count=8)
-        self.cast_in_arc(ability='bone_spear', cast_pos_abs=cast_pos_abs, spread_deg=10, time_in_s=self.damage_scaling*5)
+        self.cast_in_arc(ability='bone_spear', cast_pos_abs=cast_pos_abs, spread_deg=10, time_in_s=5)
         self._bone_armor()
 
         self._corpse_explosion(np.array(nihlathak_pos_abs)*.75, spray=200, cast_count=10)
-        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=cast_pos_abs, spread_deg=30, time_in_s=self.damage_scaling*2.5)
+        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=cast_pos_abs, spread_deg=30, time_in_s=2.5)
 
         # Move to items
         wait(self._cast_duration, self._cast_duration + 0.2)
@@ -205,13 +209,12 @@ class Bone_Necro(IChar):
 
     def kill_summoner(self) -> bool:
         # Attack
-        self.cast_in_arc(ability='teeth', cast_pos_abs=[30,30], spread_deg=360, time_in_s=self.damage_scaling*3)
-        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[30,30], spread_deg=360, time_in_s=self.damage_scaling*2)
+        self.cast_in_arc(ability='teeth', cast_pos_abs=[30,30], spread_deg=360, time_in_s=3)
+        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[30,30], spread_deg=360, time_in_s=2)
         self._corpse_explosion([0,0], spray=200, cast_count=8)
-        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[30,30], spread_deg=360, time_in_s=self.damage_scaling*2)
+        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[30,30], spread_deg=360, time_in_s=2)
             
         return True               
-
 
 if __name__ == "__main__":
     import os

--- a/src/char/bone_necro.py
+++ b/src/char/bone_necro.py
@@ -169,12 +169,13 @@ class Bone_Necro(IChar):
         #moat on right side, encircle with bone walls on the other 3 sides
         for pos in [[100,-100], [-125,-25], [-50,100]]:
             self.bone_wall(pos, spray=10)
-        self.cast_in_arc(ability='teeth', cast_pos_abs=[25,-100], spread_deg=270, time_in_s=self.damage_scaling*5)
-        self.cast_in_arc(ability='bone_spear', cast_pos_abs=[25,-100], spread_deg=120, time_in_s=self.damage_scaling*8)
-        self._corpse_explosion([25,-100], spray=200, cast_count=8)
-        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[10,-50], spread_deg=180, time_in_s=self.damage_scaling*6)
-        self._corpse_explosion([25,-100], spray=200, cast_count=8)
-        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[10,-50], spread_deg=360, time_in_s=self.damage_scaling*5)
+        self.cast_in_arc(ability='teeth', cast_pos_abs=[40,-100], spread_deg=180, time_in_s=self.damage_scaling*5)
+        self.cast_in_arc(ability='bone_spear', cast_pos_abs=[40,-100], spread_deg=120, time_in_s=self.damage_scaling*8)
+        
+        self._corpse_explosion([40,-100], spray=200, cast_count=8)
+        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[20,-50], spread_deg=180, time_in_s=self.damage_scaling*5)
+        self._corpse_explosion([40,-100], spray=200, cast_count=8)
+        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[20,-50], spread_deg=360, time_in_s=self.damage_scaling*4)
         
         return True
 
@@ -204,11 +205,10 @@ class Bone_Necro(IChar):
 
     def kill_summoner(self) -> bool:
         # Attack
-        for i in range(2):
-            self.cast_in_arc(ability='teeth', cast_pos_abs=[30,30], spread_deg=360, time_in_s=self.damage_scaling*1.5)
-        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[30,30], spread_deg=360, time_in_s=self.damage_scaling*1.5)
+        self.cast_in_arc(ability='teeth', cast_pos_abs=[30,30], spread_deg=360, time_in_s=self.damage_scaling*3)
+        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[30,30], spread_deg=360, time_in_s=self.damage_scaling*2)
         self._corpse_explosion([0,0], spray=200, cast_count=8)
-        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[30,30], spread_deg=360, time_in_s=self.damage_scaling*1.5)
+        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[30,30], spread_deg=360, time_in_s=self.damage_scaling*2)
             
         return True               
 

--- a/src/char/bone_necro.py
+++ b/src/char/bone_necro.py
@@ -22,6 +22,7 @@ class Bone_Necro(IChar):
         Logger.info("\033[94m<<Setting up Necro>>\033[0m")
         super().__init__(skill_hotkeys)
         self._pather = pather
+        self.damage_scaling = float(Config().bone_necro.get("damage_scaling", 1.0))
     
     def bone_wall(self, cast_pos_abs: Tuple[float, float], spray: int):
         if not self._skill_hotkeys["bone_wall"]:
@@ -129,9 +130,9 @@ class Bone_Necro(IChar):
     def kill_pindle(self) -> bool:
         for pos in [[200,-100], [-150,100] ]:
             self.bone_wall(pos, spray=10)
-        self.cast_in_arc(ability='bone_spear', cast_pos_abs=[110,-50], spread_deg=15, time_in_s=5)
+        self.cast_in_arc(ability='bone_spear', cast_pos_abs=[110,-50], spread_deg=15, time_in_s=self.damage_scaling*5)
         self._corpse_explosion([165,-75], spray=100, cast_count=5)
-        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[110,-50], spread_deg=15, time_in_s=2.5)
+        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[110,-50], spread_deg=15, time_in_s=self.damage_scaling*2.5)
         self._pather.traverse_nodes_fixed("pindle_end", self)
         return True
 
@@ -139,10 +140,10 @@ class Bone_Necro(IChar):
         #build an arc of bone walls
         for pos in [[50,-200], [-200,-175], [-350,50]]:
             self.bone_wall(pos, spray=10)
-        self.cast_in_arc(ability='teeth', cast_pos_abs=[-20,-150], spread_deg=15, time_in_s=3)
-        self.cast_in_arc(ability='bone_spear', cast_pos_abs=[-20,-150], spread_deg=15, time_in_s=2)
+        self.cast_in_arc(ability='teeth', cast_pos_abs=[-20,-150], spread_deg=15, time_in_s=self.damage_scaling*3)
+        self.cast_in_arc(ability='bone_spear', cast_pos_abs=[-20,-150], spread_deg=15, time_in_s=self.damage_scaling*2)
         self._corpse_explosion([-20,-240], spray=100, cast_count=5)
-        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[0,-80], spread_deg=60, time_in_s=2.5)
+        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[0,-80], spread_deg=60, time_in_s=self.damage_scaling*2.5)
         self._pather.traverse_nodes((Location.A5_ELDRITCH_SAFE_DIST, Location.A5_ELDRITCH_END), self, timeout=0.6, force_tp=True)
         self.bone_armor()
         return True
@@ -150,12 +151,12 @@ class Bone_Necro(IChar):
 
     def kill_shenk(self) -> bool:
         self._cast_circle(cast_dir=[1,1],cast_start_angle=0,cast_end_angle=360,cast_div=5,cast_spell='bone_wall',delay=.8,radius=100, hold=False)
-        self.cast_in_arc(ability='teeth', cast_pos_abs=[160,75], spread_deg=360, time_in_s=6)
-        self.cast_in_arc(ability='teeth', cast_pos_abs=[160,75], spread_deg=30, time_in_s=2)
+        self.cast_in_arc(ability='teeth', cast_pos_abs=[160,75], spread_deg=360, time_in_s=self.damage_scaling*6)
+        self.cast_in_arc(ability='teeth', cast_pos_abs=[160,75], spread_deg=30, time_in_s=self.damage_scaling*2)
         self._corpse_explosion([0,0], spray=200, cast_count=4)
-        self.cast_in_arc(ability='bone_spear', cast_pos_abs=[160,75], spread_deg=30, time_in_s=3)
+        self.cast_in_arc(ability='bone_spear', cast_pos_abs=[160,75], spread_deg=30, time_in_s=self.damage_scaling*3)
         self._corpse_explosion([240,112], spray=200, cast_count=8)
-        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[80,37], spread_deg=60, time_in_s=3)
+        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[80,37], spread_deg=60, time_in_s=self.damage_scaling*3)
         self._pather.traverse_nodes((Location.A5_SHENK_SAFE_DIST, Location.A5_SHENK_END), self, timeout=1.0)
         return True
 
@@ -168,12 +169,12 @@ class Bone_Necro(IChar):
         #moat on right side, encircle with bone walls on the other 3 sides
         for pos in [[100,-100], [-125,-25], [-50,100]]:
             self.bone_wall(pos, spray=10)
-        self.cast_in_arc(ability='teeth', cast_pos_abs=[25,-100], spread_deg=270, time_in_s=5)
-        self.cast_in_arc(ability='bone_spear', cast_pos_abs=[25,-100], spread_deg=120, time_in_s=8)
+        self.cast_in_arc(ability='teeth', cast_pos_abs=[25,-100], spread_deg=270, time_in_s=self.damage_scaling*5)
+        self.cast_in_arc(ability='bone_spear', cast_pos_abs=[25,-100], spread_deg=120, time_in_s=self.damage_scaling*8)
         self._corpse_explosion([25,-100], spray=200, cast_count=8)
-        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[10,-50], spread_deg=180, time_in_s=6)
+        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[10,-50], spread_deg=180, time_in_s=self.damage_scaling*6)
         self._corpse_explosion([25,-100], spray=200, cast_count=8)
-        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[10,-50], spread_deg=360, time_in_s=5)
+        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[10,-50], spread_deg=360, time_in_s=self.damage_scaling*5)
         
         return True
 
@@ -187,14 +188,14 @@ class Bone_Necro(IChar):
         cast_pos_abs = np.array(nihlathak_pos_abs)*.2
         self._cast_circle(cast_dir=[1,1],cast_start_angle=0,cast_end_angle=360,cast_div=5,cast_spell='bone_wall',delay=.8,radius=100, hold=False)
         self._bone_armor()
-        self.cast_in_arc(ability='teeth', cast_pos_abs=cast_pos_abs, spread_deg=150, time_in_s=5)
+        self.cast_in_arc(ability='teeth', cast_pos_abs=cast_pos_abs, spread_deg=150, time_in_s=self.damage_scaling*5)
         self._bone_armor()
         self._corpse_explosion(cast_pos_abs, spray=200, cast_count=8)
-        self.cast_in_arc(ability='bone_spear', cast_pos_abs=cast_pos_abs, spread_deg=10, time_in_s=5)
+        self.cast_in_arc(ability='bone_spear', cast_pos_abs=cast_pos_abs, spread_deg=10, time_in_s=self.damage_scaling*5)
         self._bone_armor()
 
         self._corpse_explosion(np.array(nihlathak_pos_abs)*.75, spray=200, cast_count=10)
-        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=cast_pos_abs, spread_deg=30, time_in_s=2.5)
+        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=cast_pos_abs, spread_deg=30, time_in_s=self.damage_scaling*2.5)
 
         # Move to items
         wait(self._cast_duration, self._cast_duration + 0.2)
@@ -204,10 +205,10 @@ class Bone_Necro(IChar):
     def kill_summoner(self) -> bool:
         # Attack
         for i in range(2):
-            self.cast_in_arc(ability='teeth', cast_pos_abs=[30,30], spread_deg=360, time_in_s=1.5)
-        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[30,30], spread_deg=360, time_in_s=1.5)
+            self.cast_in_arc(ability='teeth', cast_pos_abs=[30,30], spread_deg=360, time_in_s=self.damage_scaling*1.5)
+        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[30,30], spread_deg=360, time_in_s=self.damage_scaling*1.5)
         self._corpse_explosion([0,0], spray=200, cast_count=8)
-        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[30,30], spread_deg=360, time_in_s=1.5)
+        self.cast_in_arc(ability='bone_spirit', cast_pos_abs=[30,30], spread_deg=360, time_in_s=self.damage_scaling*1.5)
             
         return True               
 

--- a/src/char/i_char.py
+++ b/src/char/i_char.py
@@ -10,7 +10,7 @@ from char.capabilities import CharacterCapabilities
 from ui_manager import is_visible, wait_until_visible
 from ui import skills
 from utils.custom_mouse import mouse
-from utils.misc import wait, cut_roi, is_in_roi, color_filter
+from utils.misc import wait, cut_roi, is_in_roi, color_filter, arc_spread
 from logger import Logger
 from config import Config
 from screen import grab, convert_monitor_to_screen, convert_screen_to_abs, convert_abs_to_monitor, convert_screen_to_monitor
@@ -274,6 +274,41 @@ class IChar:
             else:
                 Logger.warning("Failed to switch weapon, try again")
                 wait(0.5)
+                
+                
+    def vec_to_monitor(self, target):
+        circle_pos_screen = self._pather._adjust_abs_range_to_screen(target)
+        return convert_abs_to_monitor(circle_pos_screen)
+        
+    def cast_in_arc(self, ability: str, cast_pos_abs: Tuple[float, float] = [0,-100], time_in_s: float = 3, spread_deg: float = 10, hold=True):
+        Logger.debug(f'Casting {ability} for {time_in_s:.02f}s at {cast_pos_abs} with {spread_deg}°')
+        if not self._skill_hotkeys[ability]:
+            raise ValueError(f"You did not set {ability} hotkey!")
+        keyboard.send(Config().char["stand_still"], do_release=False)
+        keyboard.send(self._skill_hotkeys[ability])
+        wait(0.02, 0.08)
+
+        target = self.vec_to_monitor(arc_spread(cast_pos_abs, spread_deg=spread_deg))
+        mouse.move(*target,delay_factor=[0.95, 1.05])
+        if hold:
+            mouse.press(button="right")
+        start = time.time()
+        while (time.time() - start) < time_in_s:
+            target = self.vec_to_monitor(arc_spread(cast_pos_abs, spread_deg=spread_deg))
+            if hold:
+                mouse.move(*target,delay_factor=[3, 8])
+            if not hold:
+                mouse.move(*target,delay_factor=[.2, .4])
+                wait(0.02, 0.04)
+                mouse.press(button="right")
+                wait(0.02, 0.06)
+                mouse.release(button="right")
+                wait(self._cast_duration, self._cast_duration)
+                
+        if hold:
+            mouse.release(button="right")
+        keyboard.send(Config().char["stand_still"], do_press=False)
+    
 
     def pre_buff(self):
         pass

--- a/src/char/i_char.py
+++ b/src/char/i_char.py
@@ -27,6 +27,7 @@ class IChar:
         self._ocr = Ocr()
         # Add a bit to be on the save side
         self._cast_duration = Config().char["casting_frames"] * 0.04 + 0.01
+        self.damage_scaling = float(Config().char.get("damage_scaling", 1.0))
         self.capabilities = None
 
     def _discover_capabilities(self) -> CharacterCapabilities:
@@ -281,6 +282,8 @@ class IChar:
         return convert_abs_to_monitor(circle_pos_screen)
         
     def cast_in_arc(self, ability: str, cast_pos_abs: Tuple[float, float] = [0,-100], time_in_s: float = 3, spread_deg: float = 10, hold=True):
+        #scale cast time by damage_scaling
+        time_in_s *= self.damage_scaling
         Logger.debug(f'Casting {ability} for {time_in_s:.02f}s at {cast_pos_abs} with {spread_deg}°')
         if not self._skill_hotkeys[ability]:
             raise ValueError(f"You did not set {ability} hotkey!")

--- a/src/config.py
+++ b/src/config.py
@@ -45,6 +45,7 @@ class Config:
     trapsin = {}
     barbarian = {}
     poison_necro = {}
+    bone_necro = {}
     necro = {}
     basic = {}
     basic_ranged = {}
@@ -351,6 +352,10 @@ class Config:
         self.poison_necro = self.configs["config"]["parser"]["poison_necro"]
         if "poison_necro" in self.configs["custom"]["parser"]:
             self.poison_necro.update(self.configs["custom"]["parser"]["poison_necro"])
+            
+        self.bone_necro = self.configs["config"]["parser"]["bone_necro"]
+        if "bone_necro" in self.configs["custom"]["parser"]:
+            self.bone_necro.update(self.configs["custom"]["parser"]["bone_necro"])
 
         self.advanced_options = {
             "pathing_delay_factor": min(max(int(self._select_val("advanced_options", "pathing_delay_factor")), 1), 10),

--- a/src/utils/misc.py
+++ b/src/utils/misc.py
@@ -220,6 +220,17 @@ def image_is_equal(img1: np.ndarray, img2: np.ndarray) -> bool:
         Logger.debug("image_is_equal: Image shape is not equal")
         return False
     return not(np.bitwise_xor(img1, img2).any())
+    
+def arc_spread(cast_dir: Tuple[float,float], spread_deg: float=10, radius_spread: Tuple[float, float] = [.95, 1.05]):
+    """
+        Given an x,y vec (target), generate a new target that is the same vector but rotated by +/- spread_deg/2
+    """
+    cast_dir = np.array(cast_dir)
+    length = dist(cast_dir, (0, 0))
+    adj = (radius_spread[1] - radius_spread[0])*random.random() + radius_spread[0]
+    rot = spread_deg*(random.random() - .5)
+    return rotate_vec(unit_vector(cast_dir)*(length+adj), rot)
+
 
 # if __name__ == "__main__":
     # print(find_d2r_window())


### PR DESCRIPTION
Added an implementation for bone_necro with support for all runs except Chaos. 

Added cast_in_arc to i_char.py, which is heavily used by the bone_necro implementation. This function allows a skill to be cast more realistically and with reduced downtime.  The mouse is held down for some duration, and moved around while held in order to continue casting randomly within an arc (degrees is a parameter).  

This means that we cast at max speed as opposed to many other implementation in this project where there are additional delays between casts - Usually a cast, then a delay, mouse movement (with it's own delay), another delay, then another cast. 

The only downside to this approach previously, was that if the cast started on an enemy and that enemy died, the skill would stop casting for the rest of the duration. 2.4 removed this downside and the spell will continue to cast.

The existing cast times are tailored for a relatively high level and well geared necro. Testing was on a level 90 char with nearly fully synergized bone spells at level 39 and 125 FCR. To adjust for a less or better geared character, you can set the damage_scaling option under [bone_necro]. ie: damage_scaling=2 will cast all skills twice as long. 



