### PR TITLE
fix ignored claws when shopping at anya

### DIFF
--- a/src/shop/anya.py
+++ b/src/shop/anya.py
@@ -148,10 +148,21 @@ class AnyaShopper:
                 claw_pos = []
                 img = grab().copy()
                 claw_keys = ["CLAW1", "CLAW2", "CLAW3"]
-                for ck in claw_keys:
-                    template_match = TemplateFinder(True).search(ck, img, roi=self.roi_vendor)
+
+                # new approach iterates on image until all matches are added to the list
+                claws_remaining = True
+                claws_img = img.copy() # make an additional copy to avoid breaking usage of 'img' at later time
+                while claws_remaining:
+                    template_match = TemplateFinder(True).search(claw_keys, claws_img, roi=self.roi_vendor, best_match=True)
                     if template_match.valid:
                         claw_pos.append(template_match.center)
+                        # black out rectangle from image for future iterations
+                        rec = template_match.region
+                        blackout = np.zeros((rec[3], rec[2], 3))
+                        claws_img[rec[1]:(rec[1]+blackout.shape[0]), rec[0]:(rec[0]+blackout.shape[1])] = blackout
+                    else:
+                        claws_remaining = False
+
                 # check out each claw
                 for pos in claw_pos:
                     # cv2.circle(img, pos, 3, (0, 255, 0), 2)

--- a/src/shop/anya.py
+++ b/src/shop/anya.py
@@ -12,7 +12,7 @@ from logger import Logger
 from npc_manager import Npc, open_npc_menu, press_npc_btn
 from template_finder import TemplateFinder
 from utils.custom_mouse import mouse
-from utils.misc import wait, load_template
+from utils.misc import wait, load_template, mask_by_roi
 
 from messages import Messenger
 
@@ -156,10 +156,8 @@ class AnyaShopper:
                     template_match = TemplateFinder(True).search(claw_keys, claws_img, roi=self.roi_vendor, best_match=True)
                     if template_match.valid:
                         claw_pos.append(template_match.center)
-                        # black out rectangle from image for future iterations
-                        rec = template_match.region
-                        blackout = np.zeros((rec[3], rec[2], 3))
-                        claws_img[rec[1]:(rec[1]+blackout.shape[0]), rec[0]:(rec[0]+blackout.shape[1])] = blackout
+                        # mask out rectangle from image for future iterations
+                        claws_img = mask_by_roi(claws_img, template_match.region, "inverse")
                     else:
                         claws_remaining = False
 


### PR DESCRIPTION
I noticed this problem when I tried the Anya claw shopper today.

The old shopping routine would only check one match for each type of claw image, usually resulting in a max of 2 claws being checked when there are as many as 5 available.

This new method keeps iterating on the inventory image until all claw matches have been identified.