### PR TITLE
Optimize/trav

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -101,17 +101,17 @@ class Bot:
         # Adapt order to the config
         self._do_runs = OrderedDict((k, self._do_runs[k]) for k in Config().routes_order if k in self._do_runs and self._do_runs[k])
     
-        last_run = list(self._do_runs.keys())[-1]
+        runs = list(self._do_runs.keys())
         self._do_runs_reset = copy(self._do_runs)
         Logger.info(f"Doing runs: {self._do_runs_reset.keys()}")
         if Config().general["randomize_runs"]:
             self.shuffle_runs()
-        self._pindle = Pindle(self._pather, self._town_manager, self._char, self._pickit, last_run)
-        self._shenk = ShenkEld(self._pather, self._town_manager, self._char, self._pickit, last_run)
-        self._trav = Trav(self._pather, self._town_manager, self._char, self._pickit, last_run)
-        self._nihlathak = Nihlathak(self._pather, self._town_manager, self._char, self._pickit, last_run)
-        self._arcane = Arcane(self._pather, self._town_manager, self._char, self._pickit, last_run)
-        self._diablo = Diablo(self._pather, self._town_manager, self._char, self._pickit, last_run)
+        self._pindle = Pindle(self._pather, self._town_manager, self._char, self._pickit, runs)
+        self._shenk = ShenkEld(self._pather, self._town_manager, self._char, self._pickit, runs)
+        self._trav = Trav(self._pather, self._town_manager, self._char, self._pickit, runs)
+        self._nihlathak = Nihlathak(self._pather, self._town_manager, self._char, self._pickit, runs)
+        self._arcane = Arcane(self._pather, self._town_manager, self._char, self._pickit, runs)
+        self._diablo = Diablo(self._pather, self._town_manager, self._char, self._pickit, runs)
 
         # Create member variables
         self._picked_up_items = False

--- a/src/bot.py
+++ b/src/bot.py
@@ -100,16 +100,18 @@ class Bot:
         }
         # Adapt order to the config
         self._do_runs = OrderedDict((k, self._do_runs[k]) for k in Config().routes_order if k in self._do_runs and self._do_runs[k])
+    
+        last_run = list(self._do_runs.keys())[-1]
         self._do_runs_reset = copy(self._do_runs)
         Logger.info(f"Doing runs: {self._do_runs_reset.keys()}")
         if Config().general["randomize_runs"]:
             self.shuffle_runs()
-        self._pindle = Pindle(self._pather, self._town_manager, self._char, self._pickit)
-        self._shenk = ShenkEld(self._pather, self._town_manager, self._char, self._pickit)
-        self._trav = Trav(self._pather, self._town_manager, self._char, self._pickit)
-        self._nihlathak = Nihlathak(self._pather, self._town_manager, self._char, self._pickit)
-        self._arcane = Arcane(self._pather, self._town_manager, self._char, self._pickit)
-        self._diablo = Diablo(self._pather, self._town_manager, self._char, self._pickit)
+        self._pindle = Pindle(self._pather, self._town_manager, self._char, self._pickit, last_run)
+        self._shenk = ShenkEld(self._pather, self._town_manager, self._char, self._pickit, last_run)
+        self._trav = Trav(self._pather, self._town_manager, self._char, self._pickit, last_run)
+        self._nihlathak = Nihlathak(self._pather, self._town_manager, self._char, self._pickit, last_run)
+        self._arcane = Arcane(self._pather, self._town_manager, self._char, self._pickit, last_run)
+        self._diablo = Diablo(self._pather, self._town_manager, self._char, self._pickit, last_run)
 
         # Create member variables
         self._picked_up_items = False

--- a/src/run/arcane.py
+++ b/src/run/arcane.py
@@ -21,14 +21,14 @@ class Arcane:
         town_manager: TownManager,
         char: IChar,
         pickit: PickIt,
-        last_run: str
+        runs: list[str]
     ):
         self._pather = pather
         self._town_manager = town_manager
         self._char = char
         self._pickit = pickit
         self._chest = Chest(self._char, 'arcane')
-        self._is_last_run = last_run == self.name
+        self._runs = runs
 
     def approach(self, start_loc: Location) -> bool | Location:
         Logger.info("Run Arcane")

--- a/src/run/arcane.py
+++ b/src/run/arcane.py
@@ -12,18 +12,23 @@ from ui import waypoint
 from health_manager import set_pause_state
 
 class Arcane:
+
+    name = "run_arcane"
+
     def __init__(
         self,
         pather: Pather,
         town_manager: TownManager,
         char: IChar,
         pickit: PickIt,
+        last_run: str
     ):
         self._pather = pather
         self._town_manager = town_manager
         self._char = char
         self._pickit = pickit
         self._chest = Chest(self._char, 'arcane')
+        self._is_last_run = last_run == self.name
 
     def approach(self, start_loc: Location) -> bool | Location:
         Logger.info("Run Arcane")

--- a/src/run/diablo.py
+++ b/src/run/diablo.py
@@ -15,12 +15,16 @@ from ui import skills, loading, waypoint
 from inventory import belt, personal
 
 class Diablo:
+
+    name = "run_diablo"
+
     def __init__(
         self,
         pather: Pather,
         town_manager: TownManager,
         char: IChar,
-        pickit: PickIt
+        pickit: PickIt,
+        last_run: str
     ):
         self._pather = pather
         self._town_manager = town_manager

--- a/src/run/diablo.py
+++ b/src/run/diablo.py
@@ -24,7 +24,7 @@ class Diablo:
         town_manager: TownManager,
         char: IChar,
         pickit: PickIt,
-        last_run: str
+        runs: list[str]
     ):
         self._pather = pather
         self._town_manager = town_manager
@@ -33,6 +33,7 @@ class Diablo:
         self._picked_up_items = False
         self.used_tps = 0
         self._curr_loc: bool | Location = Location.A4_TOWN_START
+        self._runs = runs
 
     def approach(self, start_loc: Location) -> bool | Location:
 

--- a/src/run/nihlathak.py
+++ b/src/run/nihlathak.py
@@ -12,17 +12,22 @@ import random
 from ui import loading, waypoint
 
 class Nihlathak:
+
+    name = "run_nihlathak"
+
     def __init__(
         self,
         pather: Pather,
         town_manager: TownManager,
         char: IChar,
-        pickit: PickIt
+        pickit: PickIt,
+        last_run: str
     ):
         self._pather = pather
         self._town_manager = town_manager
         self._char = char
         self._pickit = pickit
+        self._is_last_run = last_run == self.name
 
     def approach(self, start_loc: Location) -> bool | Location:
         Logger.info("Run Nihlathak")

--- a/src/run/nihlathak.py
+++ b/src/run/nihlathak.py
@@ -21,13 +21,13 @@ class Nihlathak:
         town_manager: TownManager,
         char: IChar,
         pickit: PickIt,
-        last_run: str
+        runs: list[str]
     ):
         self._pather = pather
         self._town_manager = town_manager
         self._char = char
         self._pickit = pickit
-        self._is_last_run = last_run == self.name
+        self._runs = runs
 
     def approach(self, start_loc: Location) -> bool | Location:
         Logger.info("Run Nihlathak")

--- a/src/run/pindle.py
+++ b/src/run/pindle.py
@@ -8,17 +8,22 @@ from utils.misc import wait
 from ui import loading
 
 class Pindle:
+
+    name = "run_pindle"
+
     def __init__(
         self,
         pather: Pather,
         town_manager: TownManager,
         char: IChar,
-        pickit: PickIt
+        pickit: PickIt,
+        last_run: str
     ):
         self._pather = pather
         self._town_manager = town_manager
         self._char = char
         self._pickit = pickit
+        self._is_last_run = last_run == self.name
 
     def approach(self, start_loc: Location) -> bool | Location:
         # Go through Red Portal in A5

--- a/src/run/pindle.py
+++ b/src/run/pindle.py
@@ -17,13 +17,13 @@ class Pindle:
         town_manager: TownManager,
         char: IChar,
         pickit: PickIt,
-        last_run: str
+        runs: list[str]
     ):
         self._pather = pather
         self._town_manager = town_manager
         self._char = char
         self._pickit = pickit
-        self._is_last_run = last_run == self.name
+        self.runs = runs
 
     def approach(self, start_loc: Location) -> bool | Location:
         # Go through Red Portal in A5

--- a/src/run/shenk_eld.py
+++ b/src/run/shenk_eld.py
@@ -8,17 +8,22 @@ from utils.misc import wait
 from ui import waypoint
 
 class ShenkEld:
+
+    name = "run_shenk"
+
     def __init__(
         self,
         pather: Pather,
         town_manager: TownManager,
         char: IChar,
-        pickit: PickIt
+        pickit: PickIt,
+        last_run: str
     ):
         self._pather = pather
         self._town_manager = town_manager
         self._char = char
         self._pickit = pickit
+        self._is_last_run = last_run == self.name
 
     def approach(self, start_loc: Location) -> bool | Location:
         Logger.info("Run Eldritch")

--- a/src/run/shenk_eld.py
+++ b/src/run/shenk_eld.py
@@ -17,13 +17,13 @@ class ShenkEld:
         town_manager: TownManager,
         char: IChar,
         pickit: PickIt,
-        last_run: str
+        runs: list[str]
     ):
         self._pather = pather
         self._town_manager = town_manager
         self._char = char
         self._pickit = pickit
-        self._is_last_run = last_run == self.name
+        self._runs = runs
 
     def approach(self, start_loc: Location) -> bool | Location:
         Logger.info("Run Eldritch")

--- a/src/run/trav.py
+++ b/src/run/trav.py
@@ -52,7 +52,7 @@ class Trav:
         wait(0.2, 0.3)
         # If we can teleport we want to move back inside and also check loot there
         if self._char.capabilities.can_teleport_natively or self._char.capabilities.can_teleport_with_charges:
-            if not self._pather.traverse_nodes([229], self._char, timeout=2.5, use_tp_charge=True):
+            if not self._pather.traverse_nodes([229], self._char, timeout=2.5, use_tp_charge=self._char.capabilities.can_teleport_natively):
                 self._pather.traverse_nodes([228, 229], self._char, timeout=2.5, use_tp_charge=True)
             picked_up_items |= self._pickit.pick_up_items(self._char)
         if not self._is_last_run:

--- a/src/run/trav.py
+++ b/src/run/trav.py
@@ -9,17 +9,22 @@ from utils.misc import wait
 from ui import waypoint
 
 class Trav:
+
+    name = "run_trav"
+
     def __init__(
         self,
         pather: Pather,
         town_manager: TownManager,
         char: IChar,
-        pickit: PickIt
+        pickit: PickIt,
+        last_run: str,
     ):
         self._pather = pather
         self._town_manager = town_manager
         self._char = char
         self._pickit = pickit
+        self._is_last_run = last_run == self.name
 
     def approach(self, start_loc: Location) -> bool | Location:
         # Go to Travincal via waypoint
@@ -50,6 +55,7 @@ class Trav:
             if not self._pather.traverse_nodes([229], self._char, timeout=2.5, use_tp_charge=True):
                 self._pather.traverse_nodes([228, 229], self._char, timeout=2.5, use_tp_charge=True)
             picked_up_items |= self._pickit.pick_up_items(self._char)
-        # Make sure we go back to the center to not hide the tp
-        self._pather.traverse_nodes([230], self._char, timeout=2.5)
+        if not self._is_last_run:
+            # Make sure we go back to the center to not hide the tp
+            self._pather.traverse_nodes([230], self._char, timeout=2.5)
         return (Location.A3_TRAV_CENTER_STAIRS, picked_up_items)

--- a/src/run/trav.py
+++ b/src/run/trav.py
@@ -18,13 +18,13 @@ class Trav:
         town_manager: TownManager,
         char: IChar,
         pickit: PickIt,
-        last_run: str,
+        runs: list[str]
     ):
         self._pather = pather
         self._town_manager = town_manager
         self._char = char
         self._pickit = pickit
-        self._is_last_run = last_run == self.name
+        self._runs = runs
 
     def approach(self, start_loc: Location) -> bool | Location:
         # Go to Travincal via waypoint
@@ -55,7 +55,8 @@ class Trav:
             if not self._pather.traverse_nodes([229], self._char, timeout=2.5, use_tp_charge=self._char.capabilities.can_teleport_natively):
                 self._pather.traverse_nodes([228, 229], self._char, timeout=2.5, use_tp_charge=True)
             picked_up_items |= self._pickit.pick_up_items(self._char)
-        if not self._is_last_run:
+        # If travincal run is not the last run
+        if self.name != self._runs[-1]:
             # Make sure we go back to the center to not hide the tp
             self._pather.traverse_nodes([230], self._char, timeout=2.5)
         return (Location.A3_TRAV_CENTER_STAIRS, picked_up_items)


### PR DESCRIPTION
- Pass list of run scripts in chronological order to each type of run. This allows for optimizations. This kind of optimization is added to run_trav when run_trav is the last script. Skip teleporting into position so that tp is not blocked, simply just exit instead.

- Trav optimization: Prefer to not use tele charges when getting back inside to loot when using charges. Only use tele charge if pathway was blocked. This change makes the bot use less tele charges, and thereby improve run speed due to not having to repair as often. If you can tele natively the change will not affect behavior.

