### PR TITLE
Hdin pindle tele charges

### DIFF
--- a/src/char/hammerdin.py
+++ b/src/char/hammerdin.py
@@ -77,8 +77,9 @@ class Hammerdin(IChar):
 
     def kill_pindle(self) -> bool:
         wait(0.1, 0.15)
-        if self.capabilities.can_teleport_natively:
-            self._pather.traverse_nodes_fixed("pindle_end", self)
+        if self.capabilities.can_teleport_nativel or self.capabilities.can_teleport_with_charges:
+            if not self._pather.traverse_nodes([104], self._char, timeout=2.5, use_tp_charge=self.capabilities.can_teleport_natively): return False
+            #self._pather.traverse_nodes_fixed("pindle_end", self)
         else:
             if not self._do_pre_move:
                 keyboard.send(self._skill_hotkeys["concentration"])

--- a/src/char/hammerdin.py
+++ b/src/char/hammerdin.py
@@ -77,8 +77,10 @@ class Hammerdin(IChar):
 
     def kill_pindle(self) -> bool:
         wait(0.1, 0.15)
-        if self.capabilities.can_teleport_nativel or self.capabilities.can_teleport_with_charges:
-            if not self._pather.traverse_nodes([104], self._char, timeout=2.5, use_tp_charge=self.capabilities.can_teleport_natively): return False
+        if self.capabilities.can_teleport_natively or self.capabilities.can_teleport_with_charges:
+            keyboard.send(self._skill_hotkeys["teleport"])
+            if not self._pather.traverse_nodes([104], self, timeout=1.0, force_tp=True, use_tp_charge=self.capabilities.can_teleport_natively):
+                return False
             #self._pather.traverse_nodes_fixed("pindle_end", self)
         else:
             if not self._do_pre_move:

--- a/src/char/hammerdin.py
+++ b/src/char/hammerdin.py
@@ -78,7 +78,6 @@ class Hammerdin(IChar):
     def kill_pindle(self) -> bool:
         wait(0.1, 0.15)
         if self.capabilities.can_teleport_with_charges:
-            keyboard.send(self._skill_hotkeys["teleport"])
             if not self._pather.traverse_nodes([104], self, timeout=1.0, force_tp=True, use_tp_charge=True):
                 return False
         elif self.capabilities.can_teleport_natively:

--- a/src/char/hammerdin.py
+++ b/src/char/hammerdin.py
@@ -77,11 +77,13 @@ class Hammerdin(IChar):
 
     def kill_pindle(self) -> bool:
         wait(0.1, 0.15)
-        if self.capabilities.can_teleport_natively or self.capabilities.can_teleport_with_charges:
+        if self.capabilities.can_teleport_with_charges:
             keyboard.send(self._skill_hotkeys["teleport"])
             if not self._pather.traverse_nodes([104], self, timeout=1.0, force_tp=True, use_tp_charge=self.capabilities.can_teleport_natively):
                 return False
-            #self._pather.traverse_nodes_fixed("pindle_end", self)
+        elif self.capabilities.can_teleport_natively:
+            if not self._pather.traverse_nodes_fixed("pindle_end", self):
+                return False
         else:
             if not self._do_pre_move:
                 keyboard.send(self._skill_hotkeys["concentration"])

--- a/src/char/hammerdin.py
+++ b/src/char/hammerdin.py
@@ -79,7 +79,7 @@ class Hammerdin(IChar):
         wait(0.1, 0.15)
         if self.capabilities.can_teleport_with_charges:
             keyboard.send(self._skill_hotkeys["teleport"])
-            if not self._pather.traverse_nodes([104], self, timeout=1.0, force_tp=True, use_tp_charge=self.capabilities.can_teleport_natively):
+            if not self._pather.traverse_nodes([104], self, timeout=1.0, force_tp=True, use_tp_charge=True):
                 return False
         elif self.capabilities.can_teleport_natively:
             if not self._pather.traverse_nodes_fixed("pindle_end", self):


### PR DESCRIPTION
Walking Paladins at Pindle often get charged.
Using an Amulet with Telecharges can provide safety & accuracy.
Pindle Script was adapted for Hdin to teleport the last traverse to [104] (Pindle_end) in case a teleport charges (or native teleport) is available.