### PR TITLE
Added new param: Prefer_act4_town

### DIFF
--- a/config/params.ini
+++ b/config/params.ini
@@ -62,6 +62,7 @@ battle_command=f8
 stash_gold=1
 min_gold_to_pick=1000
 use_merc=1
+prefer_act4_town=1
 ; Attack length for barbarians should be as high as 8-10 and even 10-12 for trav/shenk
 atk_len_arc=2.5
 atk_len_trav=3.0

--- a/src/config.py
+++ b/src/config.py
@@ -307,6 +307,7 @@ class Config:
             "gamble_items": False if not self._select_val("char", "gamble_items") else self._select_val("char", "gamble_items").replace(" ","").split(","),
             "sell_junk": bool(int(self._select_val("char", "sell_junk"))),
             "enable_no_pickup": bool(int(self._select_val("char", "enable_no_pickup"))),
+            "prefer_act4_town": bool(int(self._select_val("char", "enable_no_pickup"))),
         }
         # Sorc base config
         sorc_base_cfg = dict(self.configs["config"]["parser"]["sorceress"])

--- a/src/health_manager.py
+++ b/src/health_manager.py
@@ -15,18 +15,29 @@ from ui_manager import ScreenObjects, is_visible
 from random import uniform
 
 pause_state = True
+panel_check_paused = False
 
 def get_pause_state():
-    global pause_state
     return pause_state
 
 def set_pause_state(state: bool):
     global pause_state
     prev = get_pause_state()
     if prev != state:
-        debug_str = "pausing" if state else "active"
+        debug_str = "paused" if state else "active"
         Logger.info(f"Health Manager is now {debug_str}")
         pause_state = state
+
+def get_panel_check_paused():
+    return panel_check_paused
+
+def set_panel_check_paused(state: bool):
+    global panel_check_paused
+    prev = get_panel_check_paused()
+    if prev != state:
+        debug_str = "pausing" if state else "activating"
+        Logger.info(f"Health Manager is now {debug_str} inventory panel check")
+        panel_check_paused = state
 
 class HealthManager:
     def __init__(self):
@@ -124,7 +135,7 @@ class HealthManager:
                     elif merc_health_percentage <= Config().char["heal_merc"] and last_drink > merc_hp_potion_delay:
                         belt.drink_potion("health", merc=True, stats=[merc_health_percentage])
                         self._last_merc_heal = time.time()
-                if is_visible(ScreenObjects.LeftPanel, img) or is_visible(ScreenObjects.RightPanel, img):
+                if not get_panel_check_paused() and (is_visible(ScreenObjects.LeftPanel, img) or is_visible(ScreenObjects.RightPanel, img)):
                     Logger.warning(f"Found an open inventory / quest / skill / stats page. Close it.")
                     self._count_panel_detects += 1
                     if self._count_panel_detects >= 2:

--- a/src/run/trav.py
+++ b/src/run/trav.py
@@ -5,8 +5,10 @@ from item.pickit import PickIt
 import template_finder
 from town.town_manager import TownManager
 from utils.misc import wait
-
+from config import Config
 from ui import waypoint
+from health_manager import get_panel_check_paused, set_panel_check_paused
+
 
 class Trav:
 
@@ -59,4 +61,17 @@ class Trav:
         if self.name != self._runs[-1]:
             # Make sure we go back to the center to not hide the tp
             self._pather.traverse_nodes([230], self._char, timeout=2.5)
-        return (Location.A3_TRAV_CENTER_STAIRS, picked_up_items)
+        if Config().char["prefer_act4_town"]:
+            Logger.debug("Going to A4 town to shorten run duration (start next game in A4, or perform maintenance in the smallest town")
+            self._char.tp_town()
+            wait(0.4)
+            curr_loc = Location.A3_STASH_WP
+            set_panel_check_paused(True)
+            if not self._town_manager.open_wp(curr_loc):
+                return False
+            wait(0.4)
+            if waypoint.use_wp("The Pandemonium Fortress"):
+                set_panel_check_paused(False)
+                return (Location.A4_WP, picked_up_items)
+        else:
+            return (Location.A3_TRAV_CENTER_STAIRS, picked_up_items)


### PR DESCRIPTION
The most efficient way to farm Trivial is to end the run in A4, instead of A3.
The subsequent runs will be faster, as A3 town is rather large, and traverse to WP & Vendors takes longer.

Setting "prefer_act4_town" to 1 will trigger a TP at the end of Travincal, and our char traversing to A4 town to end the run there.

Intensive testing on a fully geared Enigma Hammerdin revealed that average run duration decreased from 82 to 71 seconds (12% improvement). For a typical farming day of 12h, instead of completing 525 runs, additional 85 runs can be performed (total 610 runs).

The methodology can be adapted to other runs such as Arcane, the benefit here, will however be much less.