### PR TITLE
fix: handle keyerror during backup settings

### DIFF
--- a/src/utils/auto_settings.py
+++ b/src/utils/auto_settings.py
@@ -44,10 +44,13 @@ def backup_settings():
             return
     f = open(current_file)
     curr_settings = json.load(f)
-    launch_options = curr_settings["Games"]["osi"]["AdditionalLaunchArguments"]
-    with open(backup_file, 'w') as f:
-        f.write(launch_options)
-    print("D2R launch options backed up successfully.")
+    try:
+        launch_options = curr_settings["Games"]["osi"]["AdditionalLaunchArguments"]
+        with open(backup_file, 'w') as f:
+            f.write(launch_options)
+        print("D2R launch options backed up successfully.")
+    except KeyError:
+        pass
 
 def restore_settings_from_backup():
     d2_saved_games = get_d2r_folder()


### PR DESCRIPTION
Keyerror when `["AdditionalLaunchArguments"`] is missing during backup settings. Proposing that it should just pass since you can't do anything about it at that moment.