### PR TITLE
Bugfix: Character select screen, character not found

### DIFF
--- a/config/game.ini
+++ b/config/game.ini
@@ -120,7 +120,7 @@ shrine_check=500,50,350,100
 character_select=1033, 44, 226, 554
 character_online_status=1033, 19, 226, 25
 ; character_sub_roi is with respect to matched active character template
-character_name_sub_roi=8, 22, 192, 32
+character_name_sub_roi=8, 23, 192, 16
 cube_area_roi=167,209,113,152
 cube_btn_roi=160,368,125,57
 xp_bar_text=369,630,554,34

--- a/config/game.ini
+++ b/config/game.ini
@@ -120,7 +120,7 @@ shrine_check=500,50,350,100
 character_select=1033, 44, 226, 554
 character_online_status=1033, 19, 226, 25
 ; character_sub_roi is with respect to matched active character template
-character_name_sub_roi=8, 23, 192, 16
+character_name_sub_roi=8, 22, 186, 18
 cube_area_roi=167,209,113,152
 cube_btn_roi=160,368,125,57
 xp_bar_text=369,630,554,34

--- a/config/game.ini
+++ b/config/game.ini
@@ -120,7 +120,7 @@ shrine_check=500,50,350,100
 character_select=1033, 44, 226, 554
 character_online_status=1033, 19, 226, 25
 ; character_sub_roi is with respect to matched active character template
-character_name_sub_roi=8, 22, 186, 18
+character_name_sub_roi=6, 22, 186, 18
 cube_area_roi=167,209,113,152
 cube_btn_roi=160,368,125,57
 xp_bar_text=369,630,554,34


### PR DESCRIPTION
problem is due to slight variations in vertical spacing between character name and level depending on how far you are scrolled on CSS. Fixed by taking a smaller crop of the saved character template which captures only the character name.