### PR TITLE
Revert: paladin timeout on trav

### DIFF
--- a/src/char/paladin/fohdin.py
+++ b/src/char/paladin/fohdin.py
@@ -136,12 +136,12 @@ class FoHdin(Paladin):
         # traverse to nodes and attack
         nodes = [225, 226, 300]
         for i, node in enumerate(nodes):
-            self._pather.traverse_nodes([node], self, timeout=3.2, do_pre_move = False, force_tp=(self.capabilities.can_teleport_natively or i > 0), use_tp_charge=(self.capabilities.can_teleport_natively or i > 0))
+            self._pather.traverse_nodes([node], self, timeout=2.2, do_pre_move = False, force_tp=(self.capabilities.can_teleport_natively or i > 0), use_tp_charge=(self.capabilities.can_teleport_natively or i > 0))
             default_target_abs = self._pather.find_abs_node_pos(node, img := grab()) or self._pather.find_abs_node_pos(906, img) or (-50, -50)
             self._generic_foh_attack_sequence(default_target_abs=default_target_abs, min_duration=atk_len_dur, max_duration=atk_len_dur*3, default_spray=80)
 
         # return to 226 and prepare for pickit
-        self._pather.traverse_nodes([226], self, timeout=3.2, do_pre_move = False, force_tp=True, use_tp_charge=True)
+        self._pather.traverse_nodes([226], self, timeout=2.2, do_pre_move = False, force_tp=True, use_tp_charge=True)
         default_target_abs = self._pather.find_abs_node_pos(226, img := grab()) or self._pather.find_abs_node_pos(906, img) or (-50, -50)
         self._generic_foh_attack_sequence(default_target_abs=default_target_abs, max_duration=atk_len_dur*3, default_spray=80)
 

--- a/src/char/paladin/hammerdin.py
+++ b/src/char/paladin/hammerdin.py
@@ -114,13 +114,13 @@ class Hammerdin(Paladin):
         # Check out the node screenshot in assets/templates/trav/nodes to see where each node is at
         atk_len = Config().char["atk_len_trav"]
         # Go inside and hammer a bit
-        self._pather.traverse_nodes([228, 229], self, timeout=3.2, do_pre_move=False, force_tp=True, use_tp_charge=True)
+        self._pather.traverse_nodes([228, 229], self, timeout=2.2, do_pre_move=False, force_tp=True, use_tp_charge=True)
         # Move a bit back and another round
         self._move_and_attack((40, 20), atk_len)
         # Here we have two different attack sequences depending if tele is available or not
         if self.capabilities.can_teleport_natively or self.capabilities.can_teleport_with_charges:
             # Back to center stairs and more hammers
-            self._pather.traverse_nodes([226], self, timeout=3.2, do_pre_move=False, force_tp=True, use_tp_charge=True)
+            self._pather.traverse_nodes([226], self, timeout=2.2, do_pre_move=False, force_tp=True, use_tp_charge=True)
             self._cast_hammers(atk_len)
             # move a bit to the top
             self._move_and_attack((65, -30), atk_len)


### PR DESCRIPTION
I made a mistake and increased the timeout duration on trav runs for some nodes. This leads to getting attacked by council without retaliation for longer periods. Reverted that change here.