### PR TITLE
Bugfix: Handle base item miscorrecting an item to Gold

### DIFF
--- a/src/nip/actions.py
+++ b/src/nip/actions.py
@@ -53,6 +53,7 @@ def _gold_pickup(item_data: dict, expression: NIPExpression) -> bool | None:
             token.type == TokenType.ValueNTIPAliasStat
             and token.value == str(NTIPAliasStat["gold"])
             and "Amount" in item_data
+            and item_data["Amount"] is not None
         ):
             try:
                 read_gold = int(item_data["Amount"])

--- a/src/nip/actions.py
+++ b/src/nip/actions.py
@@ -49,11 +49,18 @@ def should_keep(item_data) -> tuple[bool, str]:
 def _gold_pickup(item_data: dict, expression: NIPExpression) -> bool | None:
     res = None
     for i, token in enumerate(expression.tokens):
-        if token.type == TokenType.ValueNTIPAliasStat and token.value == str(NTIPAliasStat["gold"]):
-            read_gold = int(item_data["Amount"])
-            operator = expression.tokens[i + 1].value
-            desired_gold = int(expression.tokens[i + 2].value)
-            res = eval(f"{read_gold} {operator} {desired_gold}")
+        if (
+            token.type == TokenType.ValueNTIPAliasStat
+            and token.value == str(NTIPAliasStat["gold"])
+            and "Amount" in item_data
+        ):
+            try:
+                read_gold = int(item_data["Amount"])
+                operator = expression.tokens[i + 1].value
+                desired_gold = int(expression.tokens[i + 2].value)
+                res = eval(f"{read_gold} {operator} {desired_gold}")
+            except Exception as e:
+                Logger.warning(f"Error evaluating gold pickup condition: {e}")
             break
     return res
 
@@ -95,7 +102,7 @@ def _handle_pick_eth_sockets(item_data: dict, expression: NIPExpression) -> tupl
                 else:
                     soc = -1
                 break
-    
+
 
     # pickup table:
     # * w = white, g = gray


### PR DESCRIPTION
Addresses the following. I believe it stems from an item that isn't gold being fuzzy-matched to gold but having no "amount" property.
```
[0.7.4-dev 2022-06-16 14:48:05,685] DEBUG      fuzzy_base_item_match: change SOLD -> GOLD (similarity: 75.0%)
[0.7.4-dev 2022-06-16 14:48:05,687] DEBUG      Read 7 ground items in 0.407 seconds
Exception in thread Thread-7 (start):
Traceback (most recent call last):
  File "C:\Users\aliig\miniconda3\envs\botty\lib\threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "C:\Users\aliig\miniconda3\envs\botty\lib\threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "C:\Users\aliig\Desktop\bot\botty\src\bot.py", line 163, in start
    self.trigger_or_stop('init')
  File "C:\Users\aliig\Desktop\bot\botty\src\bot.py", line 183, in trigger_or_stop
    self.trigger(name, **kwargs)
  File "C:\Users\aliig\miniconda3\envs\botty\lib\site-packages\transitions\core.py", line 899, in _get_trigger
    return event.trigger(model, *args, **kwargs)
  File "C:\Users\aliig\miniconda3\envs\botty\lib\site-packages\transitions\core.py", line 401, in trigger
    return self.machine._process(func)
  File "C:\Users\aliig\miniconda3\envs\botty\lib\site-packages\transitions\core.py", line 1201, in _process
    self._transition_queue[0]()
  File "C:\Users\aliig\miniconda3\envs\botty\lib\site-packages\transitions\core.py", line 426, in _trigger
    return self._process(event_data)
  File "C:\Users\aliig\miniconda3\envs\botty\lib\site-packages\transitions\core.py", line 435, in _process
    if trans.execute(event_data):
  File "C:\Users\aliig\miniconda3\envs\botty\lib\site-packages\transitions\core.py", line 272, in execute
    event_data.machine.callbacks(itertools.chain(event_data.machine.before_state_change, self.before), event_data)
  File "C:\Users\aliig\miniconda3\envs\botty\lib\site-packages\transitions\core.py", line 1123, in callbacks
    self.callback(func, event_data)
  File "C:\Users\aliig\miniconda3\envs\botty\lib\site-packages\transitions\core.py", line 1144, in callback
    func(*event_data.args, **event_data.kwargs)
  File "C:\Users\aliig\Desktop\bot\botty\src\bot.py", line 522, in on_run_nihlathak
    res = self._nihlathak.battle(not self._pre_buffed)
  File "C:\Users\aliig\Desktop\bot\botty\src\run\nihlathak.py", line 107, in battle
    picked_up_items = self._pickit.pick_up_items(self._char)
  File "C:\Users\aliig\Desktop\bot\botty\src\item\pickit.py", line 165, in pick_up_items
    pickup, raw_expression = should_pickup(item_dict)
  File "C:\Users\aliig\Desktop\bot\botty\src\nip\actions.py", line 143, in should_pickup
    if (res := _gold_pickup(item_data, expression)) is not None:
  File "C:\Users\aliig\Desktop\bot\botty\src\nip\actions.py", line 53, in _gold_pickup
    read_gold = int(item_data["Amount"])
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```