### PR TITLE
Enhancement: Ensure d2r_path exists before starting Botty

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -145,6 +145,9 @@ class Config:
             "restart_d2r_when_stuck": bool(int(self._select_val("general", "restart_d2r_when_stuck"))),
         }
 
+        if not os.path.exists(self.general["d2r_path"]):
+            raise ValueError(f"d2r_path {self.general['d2r_path']} does not exist, please review your params.ini settings and set to your true D2R installation directory")
+
         self.routes = {}
         order_str = self._select_val("routes", "order")
         self.routes_order = [x.strip() for x in order_str.split(",")]


### PR DESCRIPTION
On starting botty, it will check to make sure the value for d2r_path is valid before launching.

Example of invalid input:
```
[0.8.0-dev 2022-06-17 15:49:08,857] DEBUG      Loading config
Traceback (most recent call last):
  File "C:\Users\aliig\Desktop\bot\botty\src\main.py", line 7, in <module>
    import screen
  File "C:\Users\aliig\Desktop\bot\botty\src\screen.py", line 21, in <module>
    title_regex=Config().advanced_options["hwnd_window_title"],
  File "C:\Users\aliig\Desktop\bot\botty\src\config.py", line 53, in __new__
    cls._instance.load_data()
  File "C:\Users\aliig\Desktop\bot\botty\src\config.py", line 149, in load_data
    raise ValueError(f"d2r_path {self.general['d2r_path']} does not exist, please review your params.ini settings and set to your true D2R installation directory")
ValueError: d2r_path C:\Program Files (x86)\Diablo II\Diablo II Rabctail\ does not exist, please review your params.ini settings and set to your true D2R installation directory
```